### PR TITLE
Updated regular expression to match paths that include '+' character

### DIFF
--- a/renderer/tasks/patch.js
+++ b/renderer/tasks/patch.js
@@ -19,7 +19,7 @@ function getAllExpressions(data) {
  * And will replace them to string `dst`
  */
 function replacePath(src, dst) {
-    return src.replace( /(?:(?:[A-Z]\:|~){0,1}(?:\/|\\\\|\\)(?=[^\s\/]))(?:(?:[\ a-zA-Z0-9\-\_\.\$\●\-]+(?:\/|\\\\|\\)))*/gm, dst);
+    return src.replace( /(?:(?:[A-Z]\:|~){0,1}(?:\/|\\\\|\\)(?=[^\s\/]))(?:(?:[\ a-zA-Z0-9+\-\_\.\$\●\-]+(?:\/|\\\\|\\)))*/gm, dst);
 }
 
 function processTemplateFile(project, callback) {


### PR DESCRIPTION
Paths with a '+' sign in the directory name wouldn't get parsed correctly and resulted in a new regex match. For example the following expression wouldn't be replaced correctly: "$.evalFile('D:\\Something\\Project\Whatever\\Pilot+Project\\Pilot Project\\scripts\\name.js'); getName();"