### PR TITLE
Feature - asset download from s3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "morgan": "^1.6.1",
     "node-dir": "^0.1.11",
     "request": "^2.69.0",
-    "shortid": "^2.2.4"
+    "shortid": "^2.2.4",
+    "aws-sdk": "^2.157.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/renderer/tasks/download.js
+++ b/renderer/tasks/download.js
@@ -52,7 +52,8 @@ module.exports = function(project) {
         // iterate over each asset and download it (copy it)
         Promise.all(project.assets.map((asset) => {
             if (asset.type === 's3') {
-                return downloadFromS3(asset.bucket, asset.key, project.workpath, asset.name)
+                let dstFile =  asset.src.substring( asset.src.lastIndexOf('/') + 1 );
+                return downloadFromS3(asset.bucket, asset.key, project.workpath, dstFile);
             } else if (asset.type === 'url' || !isLocalPath(asset.src)) {
                 return download(asset.src, project.workpath);
             } else if (asset.type === 'path' || isLocalPath(asset.src)) {

--- a/renderer/tasks/download.js
+++ b/renderer/tasks/download.js
@@ -3,6 +3,8 @@
 const download = require('download');
 const fs       = require('fs-extra');
 const path     = require('path');
+const AWS      = require('aws-sdk');
+
 
 function isLocalPath(src) {
     return src.indexOf('http://') === -1 && src.indexOf('https://') === -1;
@@ -14,6 +16,20 @@ function copy(src, dstDir) {
         fs.copy(src, dstPath, (err) => {
             return (err ? reject(err) : resolve());
         });
+    });
+}
+
+function downloadFromS3(bucket, key, dstDir, dstName) {
+    var s3 = new AWS.S3();
+    var params = {Bucket: bucket, Key: key};
+    var file = fs.createWriteStream(path.join(dstDir, dstName));
+    return new Promise((resolve, reject) => {
+        file.on('close', function(){
+            resolve();
+        });
+        s3.getObject(params).createReadStream().on('error', function(err) {
+            reject(err);
+        }).pipe(file);
     });
 }
 
@@ -35,7 +51,9 @@ module.exports = function(project) {
 
         // iterate over each asset and download it (copy it)
         Promise.all(project.assets.map((asset) => {
-            if (asset.type === 'url' || !isLocalPath(asset.src)) {
+            if (asset.type === 's3') {
+                return downloadFromS3(asset.bucket, asset.key, project.workpath, asset.name)
+            } else if (asset.type === 'url' || !isLocalPath(asset.src)) {
                 return download(asset.src, project.workpath);
             } else if (asset.type === 'path' || isLocalPath(asset.src)) {
                 return copy(asset.src, project.workpath);

--- a/renderer/tasks/rename.js
+++ b/renderer/tasks/rename.js
@@ -19,7 +19,7 @@ module.exports = function(project) {
 
         // iterate over each file and create rename(move) callback
         for (let asset of project.assets) {
-            let src = path.join( project.workpath, path.basename(url.parse(asset.src).pathname));
+            let src = path.join( project.workpath, asset.src.substring( asset.src.lastIndexOf('/') + 1 ));
             let dst = path.join( project.workpath, asset.name );
 
             if (src === dst) continue;


### PR DESCRIPTION

# Feature overview
This feature allows you to download assets from private S3 buckets using AWS credentials for authorization. It adds a new asset type "s3"

## Setting up AWS credentials
For this to work, you will have to set up the proper AWS credentials on the renderer (the API server does not need the credentials). You can find info on setting that up [here](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html).

The credentials set will need to have read access for any of the S3 assets you wish to use.

## Example S3 asset
Here is an example of the data structure needed for adding an S3 asset to your project:
```json
{
    "type": "s3",
    "name": "your_file_name.mp3",
    "bucket": "your-s3-bucket-name",
    "key": "the/s3/key/to/your/file.mp3",
    "src": "s3://your-s3-bucket-name/the/s3/key/to/your/file.mp3"
}
```

I do not have a test to provide with this feature at this time, but I have been using it in a couple of projects for a few months now. I'm not sure how to best go about testing it, so if you have any ideas on that I would greatly appreciate them!

Please let me know if there's anything I can add or improve in regards to the documentation or code for this feature. I am really grateful for this project and I'd like to do everything I can to make it even better.