### PR TITLE
Allow setting polling delay through settings variable

### DIFF
--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -27,7 +27,7 @@ const nextJob = async (client, settings) => {
             }
         }
 
-        await delay(NEXRENDER_API_POLLING)
+        await delay(settings.polling || NEXRENDER_API_POLLING)
     } while (active)
 }
 


### PR DESCRIPTION
I find it very useful when I can change all settings using the setting object. It might be easier and more intuitive  than setting the polling delay through env variable