### PR TITLE
Prevent conflicts with concurrent requests form multiple workers

### DIFF
--- a/packages/nexrender-server/src/helpers/database.js
+++ b/packages/nexrender-server/src/helpers/database.js
@@ -50,8 +50,9 @@ const update = (uid, entry) => {
 
     const now = new Date()
     
-    if(data[value].updatedAt !== entry.updatedAt)
-        throw new Error(`Someone else updated that entry.`)
+    if(data[value].updatedAt !== entry.updatedAt) {
+        throw new Error(`Someone else updated that entry at ${data[value].updatedAt}. Your entry updatedAt is ${entry.updatedAt}`)
+    }
 
     data[value] = Object.assign({},
         data[value],

--- a/packages/nexrender-server/src/helpers/database.js
+++ b/packages/nexrender-server/src/helpers/database.js
@@ -36,6 +36,9 @@ const indexOf = value => {
 const fetch = uid => uid ? data[indexOf(uid)] : data
 
 const insert = entry => {
+    const now = new Date()
+    entry.updatedAt = now
+    entry.createdAt = now
     data.push(entry);
     setImmediate(save);
 }
@@ -45,9 +48,17 @@ const update = (uid, entry) => {
         return null;
     }
 
+    const now = new Date()
+    
+    if(data[value].updatedAt !== entry.updatedAt)
+        throw new Error(`Someone else updated that entry.`)
+
     data[value] = Object.assign({},
         data[value],
-        entry
+        entry,
+        {
+            updatedAt: now
+        }
     );
 
     setImmediate(save);

--- a/packages/nexrender-server/src/helpers/database.js
+++ b/packages/nexrender-server/src/helpers/database.js
@@ -37,8 +37,10 @@ const fetch = uid => uid ? data[indexOf(uid)] : data
 
 const insert = entry => {
     const now = new Date()
-    entry.updatedAt = now
-    entry.createdAt = now
+    Object.assign({}, entry, {
+        updatedAt: now,
+        createdAt: now
+    })
     data.push(entry);
     setImmediate(save);
 }
@@ -54,10 +56,7 @@ const update = (uid, entry) => {
         throw new Error(`Someone else updated that entry at ${data[value].updatedAt}. Your entry updatedAt is ${entry.updatedAt}`)
     }
 
-    data[value] = Object.assign({},
-        data[value],
-        entry,
-        {
+    data[value] = Object.assign({}, data[value], entry, {
             updatedAt: now
         }
     );

--- a/packages/nexrender-server/src/routes/jobs-create.js
+++ b/packages/nexrender-server/src/routes/jobs-create.js
@@ -7,8 +7,6 @@ module.exports = async (req, res) => {
     const data = await json(req)
     const job  = create(data); {
         job.state = 'queued';
-        job.createdAt = new Date();
-        job.updatedAt = new Date();
     }
 
     console.log(`creating new job ${job.uid}`)

--- a/packages/nexrender-server/src/routes/jobs-update.js
+++ b/packages/nexrender-server/src/routes/jobs-update.js
@@ -5,9 +5,7 @@ const { update, fetch } = require('../helpers/database')
 
 module.exports = async (req, res) => {
     const data = await json(req)
-    const job  = Object.assign({}, fetch(req.params.uid) || {}, data, {
-        updatedAt: new Date(),
-    });
+    const job  = Object.assign({}, fetch(req.params.uid) || {}, data);
 
     console.log(`updating job ${job.uid}`)
 

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -17,7 +17,7 @@ const nextJob = async (client, settings) => {
             const queued  = listing.filter(job => job.state == 'queued')
 
             if (queued.length > 0) {
-                return queued[0];
+                return queued[Math.floor(Math.random() * queued.length)];
             }
         } catch (err) {
             if (settings.stopOnError) {

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -51,7 +51,12 @@ const start = async (host, secret, settings) => {
             job.state = 'started';
         }
 
-        await client.updateJob(job.uid, job)
+        try {
+            await client.updateJob(job.uid, job)
+        } catch(err) {
+            console.log(`[${job.uid}] error while updating job state to ${job.state}. Job abandoned.`)
+            continue;
+        }
 
         try {
             job = await render(job, settings); {


### PR DESCRIPTION
1. I moved setting createdAt and updatedAt to database. I believe its clear that way because its teh db responsibility to track when something was created/updated
2. When there are multiple queued jobs they are selected by workers randomly. That helps to spread out a load between them
3. Entry in the database can be only updated when you are updating most recent version of it
4. When worker tries to start job started by someone self it abandons that job and queries server for something else

Resolves my issues #109  and #103 