### PR TITLE
Feature/add extension to destname

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/packages/nexrender-action-encode/package.json
+++ b/packages/nexrender-action-encode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexrender/action-encode",
   "author": "inlife",
-  "version": "1.0.0",
+  "version": "1.1.4",
   "main": "index.js",
   "publishConfig": {
     "access": "public"

--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -16,7 +16,9 @@ const download = (job, asset) => {
     let destName = '';
 
     /* if asset doesnt have a file name, make up a random one */
-    if (protocol === 'data' && !asset.layerName) {
+    if (asset.destName) {
+        destName = asset.destName;
+    } else if (protocol === 'data' && !asset.layerName) {
         destName = Math.random().toString(36).substring(2);
     } else {
         destName = asset.layerName || path.basename(asset.src);


### PR DESCRIPTION
hello,
i have a suggestion.
this modification adds extension to downloaded (or copied) file for layer that named without extension.

commit message:
```
Added extension to destName of download.

AE required extension to recognize file type.
AE returns error if downloaded file is no extension.
it occurs when layer name without extension.
```

(AE version 16.1.1)
i encountered this error when i want to replace audio file of various type into a layer named without extension.

it will name two extensions if layer name has extension, but i think it will not bad affect.