### PR TITLE
Implement post-render action for uploading to an S3 bucket

### DIFF
--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -3,24 +3,15 @@ const fs = require('fs')
 const path = require('path')
 const AWS = require('aws-sdk')
 
-module.exports = (job, settings, { input, params }, type) => {
+module.exports = (job, settings, { input, provider, params }, type) => {
     if (type != 'postrender') {
         throw new Error(`Action ${name} can be only run in postrender mode, you provided: ${type}.`)
     }
+    if (!provider) {
+        throw new Error(`Provider is missing.`)
+    }
     if (!params) {
         throw new Error(`Parameters are missing.`)
-    }
-    if (!params.region) {
-        throw new Error(`Region must be provided.`)
-    }
-    if (!params.bucket) {
-        throw new Error(`Bucket must be provided.`)
-    }
-    if (!params.key) {
-        throw new Error(`Key must be provided.`)
-    }
-    if (!params.acl) {
-        throw new Error(`ACL must be provided.`)
     }
 
     /* check if input has been provided */
@@ -31,38 +22,45 @@ module.exports = (job, settings, { input, params }, type) => {
 
     settings.logger.log(`[${job.uid}] starting action-upload action`)
 
-    return new Promise((resolve, reject) => {
-        var output = `https://s3-${params.region}.amazonaws.com/${params.bucket}/${params.key}`
-        settings.logger.log(`[${job.uid}] action-upload: input file ${input}`)
-        settings.logger.log(`[${job.uid}] action-upload: output file ${output}`)
-
-        fs.readFile(input, (error, data) => {
-            if (error) {
-                reject(error)
+    switch (provider) {
+        /* custom/external handlers */
+        case 's3':
+            if (!params.region) {
+                return Promise.reject(new Error('S3 region not provided.'))
+            }
+            if (!params.bucket) {
+                return Promise.reject(new Error('S3 bucket not provided.'))
+            }
+            if (!params.key) {
+                return Promise.reject(new Error('S3 key not provided.'))
+            }
+            if (!params.acl) {
+                return Promise.reject(new Error('S3 ACL not provided.'))
             }
 
-            let s3 = new AWS.S3({
-                region: params.region
-            })
-
-            let request = {
-                Bucket: params.bucket,
-                Key: params.key,
-                ACL: params.acl,
-                Body: data
-            }
-            
-            s3.putObject(request, (error, data) => {
-                if (error) {
-                    reject(error)
+            try {
+                const s3 = requireg('@nexrender/provider-s3')
+                
+                const onProgress = (e) => {
+                    var progress = e.loaded / e.total * 100
+                    settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
                 }
 
-                settings.logger.log(`[${job.uid}] action-upload: upload complete`)
-                resolve()
-            }).on('httpUploadProgress', (e) => {
-                var progress = e.loaded / e.total * 100
-                settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
-            })
-        })
-    })
+                const onComplete = () => {
+                    settings.logger.log(`[${job.uid}] action-upload: upload complete`)
+                }
+
+                const output = `https://s3-${params.region}.amazonaws.com/${params.bucket}/${params.key}`
+                settings.logger.log(`[${job.uid}] action-upload: input file ${input}`)
+                settings.logger.log(`[${job.uid}] action-upload: output file ${output}`)
+                
+                return s3.upload(input, params.region, params.bucket, params.key, params.acl, onProgress, onComplete);
+            } catch (e) {
+                return Promise.reject(new Error('AWS S3 module is not installed, use \"npm i -g @nexrender/provider-s3\" to install it.'))
+            }
+            break;
+        default:
+            return Promise.reject(new Error('unknown provider: ' + provider))
+            break;
+    }
 }

--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -1,0 +1,68 @@
+const {name} = require('./package.json')
+const fs = require('fs')
+const path = require('path')
+const AWS = require('aws-sdk')
+
+module.exports = (job, settings, { input, params }, type) => {
+    if (type != 'postrender') {
+        throw new Error(`Action ${name} can be only run in postrender mode, you provided: ${type}.`)
+    }
+    if (!params) {
+        throw new Error(`Parameters are missing.`)
+    }
+    if (!params.region) {
+        throw new Error(`Region must be provided.`)
+    }
+    if (!params.bucket) {
+        throw new Error(`Bucket must be provided.`)
+    }
+    if (!params.key) {
+        throw new Error(`Key must be provided.`)
+    }
+    if (!params.acl) {
+        throw new Error(`ACL must be provided.`)
+    }
+
+    /* check if input has been provided */
+    input = input || job.output;
+
+    /* fill absolute/relative paths */
+    if (!path.isAbsolute(input)) input = path.join(job.workpath, input);
+
+    settings.logger.log(`[${job.uid}] starting action-upload action`)
+
+    return new Promise((resolve, reject) => {
+        var output = `https://s3-${params.region}.amazonaws.com/${params.bucket}/${params.key}`
+        settings.logger.log(`[${job.uid}] action-upload: input file ${input}`)
+        settings.logger.log(`[${job.uid}] action-upload: output file ${output}`)
+
+        fs.readFile(input, (error, data) => {
+            if (error) {
+                reject(error)
+            }
+
+            let s3 = new AWS.S3({
+                region: params.region
+            })
+
+            let request = {
+                Bucket: params.bucket,
+                Key: params.key,
+                ACL: params.acl,
+                Body: data
+            }
+            
+            s3.putObject(request, (error, data) => {
+                if (error) {
+                    reject(error)
+                }
+
+                settings.logger.log(`[${job.uid}] action-upload: upload complete`)
+                resolve()
+            }).on('httpUploadProgress', (e) => {
+                var progress = e.loaded / e.total * 100
+                settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
+            })
+        })
+    })
+}

--- a/packages/nexrender-action-upload/package.json
+++ b/packages/nexrender-action-upload/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexrender/action-upload",
   "author": "inlife",
-  "version": "1.1.4",
+  "version": "1.0.0",
   "main": "index.js",
   "publishConfig": {
     "access": "public"

--- a/packages/nexrender-action-upload/package.json
+++ b/packages/nexrender-action-upload/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nexrender/action-upload",
+  "author": "inlife",
+  "version": "1.1.4",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.463.0"
+  }
+}

--- a/packages/nexrender-action-upload/readme.md
+++ b/packages/nexrender-action-upload/readme.md
@@ -1,6 +1,6 @@
 # Action: Upload
 
-Upload video to an external storageprovider ie. Amazon S3.
+Upload video to an external storage provider ie. Amazon S3.
 
 ## Installation
 
@@ -41,10 +41,19 @@ When creating your render job provide this module as one of the `postrender` act
 
 ## Providers
 
-### s3
-Format of `params` object for Amazon S3:
+Currently, only Amazon S3 is supported at this time.
 
-* `region` required argument, the region ie. "us-east-1"
-* `bucket` required argument, the S3 bucket "name-of-your-bucket".
-* `key` required argument, the S3 key ie. "folder/output.mp4"
-* `acl` required argument, the S3 ACL ie. "public-read"
+### s3
+
+```js
+{
+    'region': 'us-east-1',
+    'bucket': 'name-of-your-bucket',
+    'key': 'folder/output.mp4',
+    'acl': 'public-read'
+}
+```
+* `region` required argument, the S3 bucket region
+* `bucket` required argument, the S3 bucket
+* `key` required argument, the object key
+* `acl` required argument, the ACL

--- a/packages/nexrender-action-upload/readme.md
+++ b/packages/nexrender-action-upload/readme.md
@@ -1,0 +1,38 @@
+# Action: Upload
+
+Upload video to an Amazon S3 bucket.
+
+## Installation
+
+```
+npm i @nexrender/action-upload -g
+```
+
+## Usage
+
+When creating your render job provide this module as one of the `postrender` actions:
+
+```json
+// job.json
+{
+    "actions": {
+        "postrender": [
+            {
+                "module": "@nexrender/action-upload",
+                "input": "",
+                "params": {
+                    "region": "us-east-1",
+                    "bucket": "name-of-your-bucket",
+                    "key": "folder/output.mp4",
+                    "acl": "public-read"
+                }
+            }
+        ]
+    }
+}
+```
+
+## Information
+
+* `input` optional argument, path of the file you want to encode, can be either relative or absulte path. Defaults to current job output video file.
+* `params` required argument, object containing parameters for the S3 put object request.

--- a/packages/nexrender-action-upload/readme.md
+++ b/packages/nexrender-action-upload/readme.md
@@ -1,6 +1,6 @@
 # Action: Upload
 
-Upload video to an Amazon S3 bucket.
+Upload video to an external storageprovider ie. Amazon S3.
 
 ## Installation
 
@@ -20,6 +20,7 @@ When creating your render job provide this module as one of the `postrender` act
             {
                 "module": "@nexrender/action-upload",
                 "input": "",
+                "provider": "s3",
                 "params": {
                     "region": "us-east-1",
                     "bucket": "name-of-your-bucket",
@@ -35,4 +36,15 @@ When creating your render job provide this module as one of the `postrender` act
 ## Information
 
 * `input` optional argument, path of the file you want to encode, can be either relative or absulte path. Defaults to current job output video file.
-* `params` required argument, object containing parameters for the S3 put object request.
+* `provider` required argument, object containing the name of the provider
+* `params` required argument, object containing parameters for the upload (provider-specific)
+
+## Providers
+
+### s3
+Format of `params` object for Amazon S3:
+
+* `region` required argument, the region ie. "us-east-1"
+* `bucket` required argument, the S3 bucket "name-of-your-bucket".
+* `key` required argument, the S3 key ie. "folder/output.mp4"
+* `acl` required argument, the S3 ACL ie. "public-read"

--- a/packages/nexrender-provider-s3/package.json
+++ b/packages/nexrender-provider-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexrender/provider-s3",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "inlife",
   "main": "src/index.js",
   "dependencies": {

--- a/packages/nexrender-provider-s3/src/index.js
+++ b/packages/nexrender-provider-s3/src/index.js
@@ -4,6 +4,13 @@ const aws   = require('aws-sdk')
 /* create static api instance */
 const s3instance = new aws.S3();
 
+/* create api instance with region */
+const s3instanceWithRegion = (region) => {
+    return new aws.S3({
+        region: region
+    })
+}
+
 /* define public methods */
 const download = (src, dest, options, type) => {
     let file = fs.createWriteStream(dest);
@@ -20,8 +27,30 @@ const download = (src, dest, options, type) => {
     })
 }
 
-const upload = () => {
-    return Promise.reject(new Error('s3 provider not implemeneted'));
+const upload = (src, region, bucket, key, acl, onProgress, onComplete) => {
+    return new Promise((resolve, reject) => {
+        fs.readFile(input, (err, data) => {
+            if (err) {
+                reject(err)
+            }
+
+            const params = {
+                Bucket: bucket,
+                Key: key,
+                ACL: acl
+            }
+
+            s3instanceWithRegion(region)
+                .putObject(params, (err, data) => {
+                    if (err) {
+                        reject(err)
+                    }
+                    onComplete()
+                    resolve()
+                })
+                .on('httpUploadProgress', onProgress)
+        })
+    })
 }
 
 module.exports = {

--- a/packages/nexrender-provider-s3/src/index.js
+++ b/packages/nexrender-provider-s3/src/index.js
@@ -28,28 +28,33 @@ const download = (src, dest, options, type) => {
 }
 
 const upload = (src, region, bucket, key, acl, onProgress, onComplete) => {
+    let file = fs.createReadStream(src);
+
     return new Promise((resolve, reject) => {
-        fs.readFile(input, (err, data) => {
-            if (err) {
-                reject(err)
-            }
+        file.on('error', (err) => {
+            reject(err)
+            return
+        })
 
-            const params = {
-                Bucket: bucket,
-                Key: key,
-                ACL: acl
-            }
+        const params = {
+            Bucket: bucket,
+            Key: key,
+            ACL: acl,
+            Body: file
+        }
 
-            s3instanceWithRegion(region)
-                .putObject(params, (err, data) => {
-                    if (err) {
-                        reject(err)
-                    }
+        s3instanceWithRegion(region)
+            .upload(params, (err, data) => {
+                if (err) {
+                    reject(err)
+                }
+                else
+                {
                     onComplete()
                     resolve()
-                })
-                .on('httpUploadProgress', onProgress)
-        })
+                }
+            })
+            .on('httpUploadProgress', onProgress)
     })
 }
 


### PR DESCRIPTION
This PR implements a post-render action for uploading to an S3 bucket.

# Action: Upload

  Upload video to an external storage provider ie. Amazon S3.

  ## Installation

  ```
 npm i @nexrender/action-upload -g
 ```

  ## Usage

  When creating your render job provide this module as one of the `postrender` actions:

  ```json
 // job.json
 {
     "actions": {
         "postrender": [
             {
                 "module": "@nexrender/action-upload",
                 "input": "",
                 "provider": "s3",
                 "params": {
                     "region": "us-east-1",
                     "bucket": "name-of-your-bucket",
                     "key": "folder/output.mp4",
                     "acl": "public-read"
                 }
             }
         ]
     }
 }
 ```

  ## Information

  * `input` optional argument, path of the file you want to encode, can be either relative or absulte path. Defaults to current job output video file.
 * `provider` required argument, object containing the name of the provider
 * `params` required argument, object containing parameters for the upload (provider-specific)

  ## Providers

  Currently, only Amazon S3 is supported at this time.

  ### s3

  ```js
 {
     'region': 'us-east-1',
     'bucket': 'name-of-your-bucket',
     'key': 'folder/output.mp4',
     'acl': 'public-read'
 }
 ```
 * `region` required argument, the S3 bucket region
 * `bucket` required argument, the S3 bucket
 * `key` required argument, the object key
 * `acl` required argument, the ACL