### PR TITLE
Refinements to action-upload for S3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ There are multiple built-in modules within nexrender ecosystem:
 
 * [@nexrender/action-copy](packages/nexrender-action-copy)
 * [@nexrender/action-encode](packages/nexrender-action-encode)
-* [@nexrender/action-upload](packages/nexrender-action-upload) - TODO
+* [@nexrender/action-upload](packages/nexrender-action-upload)
 * (list will be expanded)
 
 Every module might have his own set of fields, however, `module` field is always there.

--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -42,7 +42,7 @@ module.exports = (job, settings, { input, provider, params }, type) => {
                 const s3 = requireg('@nexrender/provider-s3')
                 
                 const onProgress = (e) => {
-                    var progress = Math.ceil(e.loaded / e.total * 100)
+                    const progress = Math.ceil(e.loaded / e.total * 100)
                     settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
                 }
 

--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -42,8 +42,8 @@ module.exports = (job, settings, { input, provider, params }, type) => {
                 const s3 = requireg('@nexrender/provider-s3')
                 
                 const onProgress = (e) => {
-                    var progress = e.loaded / e.total * 100
-                    settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress.toFixed(0)}%...`)
+                    var progress = Math.ceil(e.loaded / e.total * 100)
+                    settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
                 }
 
                 const onComplete = () => {

--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -43,7 +43,7 @@ module.exports = (job, settings, { input, provider, params }, type) => {
                 
                 const onProgress = (e) => {
                     var progress = e.loaded / e.total * 100
-                    settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
+                    settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress.toFixed(0)}%...`)
                 }
 
                 const onComplete = () => {

--- a/packages/nexrender-action-upload/readme.md
+++ b/packages/nexrender-action-upload/readme.md
@@ -44,6 +44,7 @@ When creating your render job provide this module as one of the `postrender` act
 Currently, only Amazon S3 is supported at this time.
 
 ### s3
+Refer to [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) for information on setting credentials.
 
 ```js
 {


### PR DESCRIPTION
This PR makes minor refinements to the `action-upload` module for uploading to Amazon S3.
- Round progress percentage to nearest whole number ie. 53%, 98%.
- Add reference to AWS documentation for setting credentials.