### PR TITLE
Bug fix: unclean list iteration for selected compositions and layers 

### DIFF
--- a/packages/nexrender-core/src/assets/nexrender.jsx
+++ b/packages/nexrender-core/src/assets/nexrender.jsx
@@ -70,16 +70,25 @@ nexrender.selectLayersByName = function(compositionName, name, callback, types) 
     if (!types) types = nexrender.types;
 
     nexrender.selectCompositionsByName(compositionName, function(comp) {
+        var items = [];
+
+        /* step 1: collect all matching layers */
         for (var j = 1; j <= comp.numLayers; j++) {
             var layer = comp.layer(j);
             if (layer.name != name) continue;
 
             if (nexrender.typesMatch(types, layer)) {
-                callback(layer, name);
                 foundOnce = true;
+                items.push(layer);
             }
         }
-    })
+
+        /* step 2: envoke callback for every match */
+        var len = items.length;
+        for (var i = 0; i < len; i++) {
+            callback(items[i], name);
+        }
+    });
 
     if (!foundOnce) {
         throw new Error("nexrender: Cound't find any layers by provided name (" + name + ") inside a composition: " + compositionName);

--- a/packages/nexrender-core/src/assets/nexrender.jsx
+++ b/packages/nexrender-core/src/assets/nexrender.jsx
@@ -34,31 +34,30 @@ nexrender.replaceFootage = function (layer, filepath) {
     return true;
 };
 
-/* call callback for an every compostion matching specific name */
+/* envoke callback for every compostion matching specific name */
 nexrender.selectCompositionsByName = function(name, callback) {
-    var foundOnce = false;
+    var items = [];
 
-    /* length might change when calling callbacks */
+    /* step 1: collect all matching compositions */
     var len = app.project.items.length;
     for (var i = 1; i <= len; i++) {
         var item = app.project.items[i];
         if (!(item instanceof CompItem)) continue;
 
-        if (name == "*") {
-            foundOnce = true;
-            callback(item);
+        if (name != "*" && item.name != name) {
             continue;
+        } else {
+            items.push(item);        
         }
-
-        if (item.name != name) {
-            continue;
-        }
-
-        foundOnce = true;
-        callback(item);
     }
 
-    if (!foundOnce) {
+    /* step 2: envoke callback for every match */
+    var len = items.length;
+    for (var i = 0; i < len; i++) {
+        callback(items[i]);        
+    }
+
+    if (len == 0) {
         throw new Error("nexrender: Cound't find any compositions by provided name (" + name + ")");
     }
 };


### PR DESCRIPTION
This bug occurs when layers or compositions are selected by name and the provided callback adds a new layer or composition. Then it happens frequently, that the selected item is selected *again* as it is moved one index up in the item list.

E.g, we had the case that calling `replaceFootage` with a file named `data_something.mp4` and adding it to `RenderComp` would add this file many times. AE would for unknown reason stop to add it after about 26 times, but on some render machines this was enough to crash rendering because of memory issues. Therefore, I would flag this bug as **serious**.

The fix will now make two separate iterations. The first will find all matching items and then a second iteration on a separate array of the found items will envoke the callback.
The bug has been fixed for selecting compositions and layers by name. 
Selecting layers by index should not suffer from the bug.

This bug is partly (for compositions) due to my own question #226.
Sorry for that!