### PR TITLE
Allow adding a file extension when downloading files

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ by specifying `src`, and one of the `layerName` or `layerIndex` options.
 * `layerName`: string, target layer name in the After Effects project
 * `layerIndex`: integer, can be used instead of `layerName` to select a layer by providing an index, starting from 1 (default behavior of AE jsx scripting env)
 * `composition`: string, composition where the layer is, useful for searching layer in pre-compositions. If none is provided, it uses the default composition set in the template.
-Providing `"*"` will result in a wildcard compostion matching, and will apply this data to every matching layer in every matching composition.
+Providing `"*"` will result in a wildcard composition matching, and will apply this data to every matching layer in every matching composition.
+* `extension`: string, an optional extension to be added to the filename before it is sent for rendering. This is because After Effects expects the file extension to match the content type of the file. If none is provided, the filename will be unchanged.
 
 Specified asset from `src` field will be downloaded/copied to the working directory, and just before rendering will happen,
 a footage item with specified `layerName` or `layerIndex` in the original project will be replaced with the freshly downloaded asset.
@@ -406,6 +407,12 @@ This way you (if you are using network rendering) you can not only deliver asset
             "src": "https://example.com/assets/image.jpg",
             "type": "image",
             "layerName": "MyNicePicture.jpg"
+        },
+        {
+            "src": "https://example.com/assets/jpeg-without-extension",
+            "type": "image",
+            "layerName": "MyOtherNicePicture.jpg",
+            "extension": "jpg"
         },
         {
             "src": "file:///home/assets/audio.mp3",

--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -30,6 +30,10 @@ const download = (job, settings, asset) => {
         }
     }
 
+    if (asset.extension) {
+        destName += '.' + asset.extension
+    }
+
     asset.dest = path.join(job.workpath, destName);
 
     switch (protocol) {


### PR DESCRIPTION
Hi @inlife. I have explained the rationale for this in the commit message (also copied below). I'm not 100% sure if this is the right approach to solve the problem. If you can think of a better way, let me know and I'll rework it.

After Effects appears to rely on assets having a particular extension.
For example, to replace an image, it expects the file to have an image
file extension like `.jpg`. If you feed it an image file that does not
have such an extension, `aerender` will fail rendering.

When downloading a remote image, the nexrender downloader typically
saves it to the working directory, named with the basename of the remote
path. This change allows you to optionally specify a file extension in
the job config, which will be appended to the filename when it is
downloaded.