### PR TITLE
Update GS upload to resolve promise

### DIFF
--- a/packages/nexrender-provider-gs/src/index.js
+++ b/packages/nexrender-provider-gs/src/index.js
@@ -57,9 +57,11 @@ const upload = (job, settings, src, params) => {
         const in_stream = fs.createReadStream(src)
             .on('error', reject)
         const out_stream = file.createWriteStream(options)
-            .on('close', resolve)
             .on('error', reject)
-            .on('finish', onUploadEnd)
+            .on('finish', ()=> {
+                onUploadEnd()
+                resolve()
+            })
             .on('pipe', onUploadStart)
         in_stream.pipe(out_stream)
     })


### PR DESCRIPTION
The 'close' callback is not called on createWriteStream, which meant the promise was never resolved or rejected. This fix uses the 'finish' callback to both log and resolve a complete upload.