### PR TITLE
Add ffmpeg path as array for pkg compatibility

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -6,8 +6,14 @@ const {spawn} = require('child_process')
 // TODO: make it work
 /* make sure pkg will pick up only needed binaries */
 const binaries = {
-    'darwin': path.join(__dirname, 'node_modules/ffmpeg-static/bin/darwin/x64/ffmpeg'),
-    'win32':  path.join(__dirname, 'node_modules/ffmpeg-static/bin/win32/x64/ffmpeg.exe'),
+    'darwin': [
+        path.join(__dirname, 'ffmpeg-static/bin/darwin/x64/ffmpeg'),
+        path.join(__dirname, '../../ffmpeg-static/bin/darwin/x64/ffmpeg'),
+    ], 
+    'win32': [
+        path.join(__dirname, 'ffmpeg-static/bin/win32/x64/ffmpeg.exe'),
+        path.join(__dirname, '../../ffmpeg-static/bin/win32/x64/ffmpeg.exe'),
+    ] 
 }
 
 // /snapshot/nexrender/packages/nexrender-cli/node_modules/@nexrender/core/node_modules/@nexrender/action-encode/node_modules/ffmpeg-static/bin/darwin/x64/ffmpeg
@@ -21,7 +27,8 @@ const getBinary = (job, settings) => {
                 return resolve(output);
             }
 
-            const rd = fs.createReadStream(binaries[process.platform])
+            const binpath = binaries[process.platform].filter(file => fs.existsSync(file))[0]
+            const rd = fs.createReadStream(binpath)              
             const wr = fs.createWriteStream(output)
 
             const handleError = err => {

--- a/packages/nexrender-action-encode/package.json
+++ b/packages/nexrender-action-encode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexrender/action-encode",
   "author": "inlife",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "main": "index.js",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When building a nexrender-core project using pkg, ffmpeg can't be found and the app crashes.
The solution is to provide the correct path for pkg but this may break other implementations which relies on this module, therefore both paths are present and tested for validity. 