### PR TITLE
Add functionality to pipe stdout/stderr to logger

### DIFF
--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -103,11 +103,11 @@ module.exports = (job, settings) => {
         instance.on('error', err => reject(new Error(`Error starting aerender process: ${err}`)));
         instance.stdout.on('data', (data) => {
             output.push(parse(data.toString('utf8')));
-            (settings.verbose && settings.logger.log(data));
+            (settings.verbose && settings.logger.log(data.toString('utf8')));
         });
         instance.stderr.on('data', (data) => {
             output.push(data.toString('utf8'));
-            (settings.verbose && settings.logger.log(data));
+            (settings.verbose && settings.logger.log(data.toString('utf8')));
         });
 
         /* on finish (code 0 - success, other - error) */

--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -101,8 +101,14 @@ module.exports = (job, settings) => {
         });
 
         instance.on('error', err => reject(new Error(`Error starting aerender process: ${err}`)));
-        instance.stdout.on('data', (data) => output.push(parse(data.toString('utf8'))));
-        instance.stderr.on('data', (data) => output.push(data.toString('utf8')));
+        instance.stdout.on('data', (data) => {
+            output.push(parse(data.toString('utf8')));
+            (settings.verbose && settings.logger.log(data));
+        });
+        instance.stderr.on('data', (data) => {
+            output.push(data.toString('utf8'));
+            (settings.verbose && settings.logger.log(data));
+        });
 
         /* on finish (code 0 - success, other - error) */
         instance.on('close', (code) => {
@@ -148,3 +154,4 @@ module.exports = (job, settings) => {
         });
     })
 };
+


### PR DESCRIPTION
## Summary
Add functionality to pipe the stdout and stderr of the child_process of the binary to the `settings.logger.log`. This allows users to hook in the log stream instead of having to read a separate log file. 

## Solution
Add a settings option like `verbose` to enable piping the result to the logger. 

### Example use-case with `child_process`: 

```js
const { spawn } = require('child_process');
const { createInterface } = require('readline');

const renderer = spawn('./render.js', ...);
const reader = createInterface({ stdin: renderer.stdout, stdout: process.stdout });
reader.on('line', data => {
  // .. to something with process output, like calculate progress...
});
```

## Testing

1. Add `verbose` to options
```js
const { init, render } = require('@nexrender/core');

const settings = init({ logger: console, verbose: true });

return render(..., settings);
```

2. Inspect the console output, you'll see output of the binary also to the console directly


