### PR TITLE
Fix ffmpeg Error: EBUSY (action-encode module)

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -40,7 +40,7 @@ const getBinary = (job, settings) => {
             rd.on('error', handleError)
             wr.on('error', handleError)
 
-            wr.on('finish', () => {
+            wr.on('close', () => {
                 fs.chmodSync(output, 0o765)
                 resolve(output)
             })

--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -168,6 +168,8 @@ module.exports = (job, settings, options, type) => {
 
                 resolve(job)
             });
+        }).catch(e => {
+            return reject(new Error('Error in action-encode module (ffmpeg)'))
         });
     });
 }


### PR DESCRIPTION
As mentioned in #330, it looks like the promise is resolved before the resources are freed and this may result in a EBUSY error. 
Since this exception is not handled, it resulted in an unhandled promise exception and the rendering promise is never settled. This may cause the flow to get stuck in certain implementations which rely on the previous job to be finished before listening for new jobs.

This small PR tries to fix both problems:

1. By listening to the "close" event on the WriteStream (https://nodejs.org/api/stream.html#stream_event_close) which ensures that the resources have been closed and they are now free before resolving the promise

2. Catches exceptions that may happen outside the ffmpeg instance (such as in this case the EBUSY error)