### PR TITLE
FIX : requiring ffmpeg-static 

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -49,7 +49,7 @@ const getBinary = (job, settings) => {
 
         } else {
             const mymodule = 'ffmpeg'; /* prevent pkg from including everything */
-            resolve(require(mymodule + '-static').path)
+            resolve(require(mymodule + '-static'))
         }
     })
 }


### PR DESCRIPTION
ffmpeg-static returns a string, there is no path property