### PR TITLE
Added settings.skipRender

### DIFF
--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -19,6 +19,7 @@ const args = arg({
     '--stop-on-error':  String,
 
     '--skip-cleanup':   Boolean,
+    '--skip-render':    Boolean,
     '--no-license':     Boolean,
     '--force-patch':    Boolean,
     '--debug':          Boolean,
@@ -88,6 +89,8 @@ if (args['--help']) {
 
     --skip-cleanup                          forces worker to keep temporary data after rendering is finished
 
+    --skip-render                           Skips rendering an output. Useful if you only want to call scripts
+
     --multi-frames                          (from Adobe site): More processes may be created to render multiple frames simultaneously,
                                             depending on system configuration and preference settings.
                                             (See Memory & Multiprocessing preferences.)
@@ -134,6 +137,7 @@ opt('binary',               '--binary');
 opt('workpath',             '--workpath');
 opt('no-license',           '--no-license');
 opt('skipCleanup',          '--skip-cleanup');
+opt('skipRender',           '--skip-render');
 opt('forceCommandLinePatch','--force-patch');
 opt('debug',                '--debug');
 opt('multiFrames',          '--multi-frames');

--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -55,6 +55,7 @@ const init = (settings) => {
         addLicense: false,
         forceCommandLinePatch: false,
         skipCleanup: false,
+        skipRender: false,
         stopOnError: true,
 
         debug: false,

--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -29,16 +29,24 @@ module.exports = (job, settings) => {
     // setup parameters
     params.push('-project', expandEnvironmentVariables(job.template.dest));
     params.push('-comp', job.template.composition);
-    params.push('-output', outputFile);
 
-    option(params, '-OMtemplate', job.template.outputModule);
-    option(params, '-RStemplate', job.template.settingsTemplate);
-    option(params, '-s', job.template.frameStart);
-    option(params, '-e', job.template.frameEnd);
-    option(params, '-i', job.template.incrementFrame);
+    if (!settings.skipRender){
+        params.push('-output', outputFile);
+
+        option(params, '-OMtemplate', job.template.outputModule);
+        option(params, '-RStemplate', job.template.settingsTemplate);
+
+        option(params, '-s', job.template.frameStart);
+        option(params, '-e', job.template.frameEnd);
+        option(params, '-i', job.template.incrementFrame);
+    } else {
+        option(params, '-s', 1);
+        option(params, '-e', 1);
+    }
+
     option(params, '-r', job.scriptfile);
 
-    if (settings.multiFrames) params.push('-mp');
+    if (!settings.skipRender && settings.multiFrames) params.push('-mp');
     if (settings.reuse) params.push('-reuse');
     if (job.template.continueOnMissing) params.push('-continueOnMissingFootage')
 
@@ -112,6 +120,7 @@ module.exports = (job, settings) => {
 
         /* on finish (code 0 - success, other - error) */
         instance.on('close', (code) => {
+
             const outputStr = output
                 .map(a => '' + a).join('');
 
@@ -130,7 +139,7 @@ module.exports = (job, settings) => {
             fs.writeFileSync(logPath, outputStr);
 
             /* resolve job without checking if file exists, or its size for image sequences */
-            if (job.template.imageSequence || ['jpeg', 'jpg', 'png'].indexOf(outputFile) !== -1) {
+            if (settings.skipRender || job.template.imageSequence || ['jpeg', 'jpg', 'png'].indexOf(outputFile) !== -1) {
                 return resolve(job)
             }
 


### PR DESCRIPTION
new settings.skipRender prop to allow nexrender to execute jsx scripts on .aep files without rendering an output. Useful for interrigation projects for things like default text values that can be stored and then manipulated manually for later rendering.