### PR TITLE
Set job.output when using skipRender

### DIFF
--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -29,9 +29,9 @@ module.exports = (job, settings) => {
     // setup parameters
     params.push('-project', expandEnvironmentVariables(job.template.dest));
     params.push('-comp', job.template.composition);
+    params.push('-output', outputFile);
 
     if (!settings.skipRender){
-        params.push('-output', outputFile);
 
         option(params, '-OMtemplate', job.template.outputModule);
         option(params, '-RStemplate', job.template.settingsTemplate);


### PR DESCRIPTION
When using skipRender setting, aerender binary fails to run because no output argument is specified (even though it is only rendering a single frame). 
Setting output regardless parameter regardless of skipRender value fixes this issue. 

Experiencing this issue on latest version of AE CC19, this is possibly not an issue in newer version of the aerender binary. 