### PR TITLE
Proposal for rewrite of encode module

### DIFF
--- a/packages/nexrender-action-encode-assets/binary.js
+++ b/packages/nexrender-action-encode-assets/binary.js
@@ -1,0 +1,64 @@
+const fs      = require('fs')
+const path    = require('path')
+const pkg     = require('./package.json')
+const fetch   = require('node-fetch')
+const nfp     = require('node-fetch-progress')
+
+const getPath = (ffmpegpath, workpath, name) => {
+  if(!path.isAbsolute(ffmpegpath)) ffmpegpath = path.join(workpath, ffmpegpath);
+  if(["/", "\\"].indexOf(ffmpegpath.charAt(ffmpegpath.length - 1)) === -1 ) return ffmpegpath;
+  else return path.join(ffmpegpath, name);
+}
+
+module.exports = (settings, ffmpeg) => {
+    return new Promise((resolve, reject) => {
+        const {version} = pkg['ffmpeg-static']
+        const fileurl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${version}/${process.platform}-x64`
+        const filename = `ffmpeg-${version}${process.platform == 'win32' ? '.exe' : ''}`
+        let output;
+
+        if(!ffmpeg){
+          output = path.join(settings.workpath, filename)
+        } else {
+          output = getPath(ffmpeg, settings.workpath, filename)
+        }
+
+        if (fs.existsSync(output)) {
+            settings.logger.log(`> using an existing ffmpeg binary ${version} at: ${output}`)
+            return resolve(output)
+        }
+
+        settings.logger.log(`> ffmpeg binary ${version} is not found`)
+        settings.logger.log(`> downloading a new ffmpeg binary ${version} to: ${output}`)
+
+      const errorHandler = (error) => {
+        reject(new Error({
+          reason: 'Unable to download file. ' + error.message,
+          meta: {fileurl, error}
+        }))
+ }
+        fetch(fileurl)
+            .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {fileurl, error: res.error}}))
+            .then(res => {
+                const progress = new nfp(res)
+
+                progress.on('progress', (p) => {
+                    process.stdout.write(`${Math.floor(p.progress * 100)}% - ${p.doneh}/${p.totalh} - ${p.rateh} - ${p.etah}\r`)
+                })
+
+                const stream = fs.createWriteStream(output)
+
+                res.body
+                    .on('error', errorHandler)
+                    .pipe(stream)
+
+                stream
+                    .on('error', errorHandler)
+                    .on('finish', () => {
+                        settings.logger.log(`> ffmpeg binary ${version} was successfully downloaded`)
+                        fs.chmodSync(output, 0o755)
+                        resolve(output)
+                    })
+            });
+    })
+}

--- a/packages/nexrender-action-encode-assets/index.js
+++ b/packages/nexrender-action-encode-assets/index.js
@@ -1,0 +1,57 @@
+const fs      = require('fs')
+const path    = require('path')
+const glob    = require('glob')
+const {spawn} = require('child_process')
+
+const getBinary  = require('./binary')
+const getPreset  = require('./presets')
+
+const getInputFiles =  (pattern) => {
+  const inputFiles = glob.sync(pattern);
+  return glob.sync(pattern).map(path.parse)
+}
+
+module.exports = async (job, settings, options, type) => {
+  settings.logger.log(`[${job.uid}] starting action-encode action (ffmpeg)`)
+
+  let {preset, params = {}, ffmpeg, input, output} = options;
+  if(!input) input = output
+
+  try {
+    const binary = await getBinary(settings, ffmpeg)
+    const inputPath = path.parse((( !path.isAbsolute(input)) ? path.join(settings.workpath, input) : input));
+
+    settings.logger.log(`[${job.uid}] action-encode: looking for files at ${inputPath.dir}/${inputPath.base}`)
+    const inputFiles = getInputFiles(`${inputPath.dir}/${inputPath.base}`);
+    settings.logger.log(`[${job.uid}] action-encode: converting ${inputFiles.length} files`)
+
+    for(const inputFile of inputFiles) {
+      const inputPath = `${ inputFile.dir }/${ inputFile.base }`
+      const outputPath = `${ inputFile.dir }/${ inputFile.name }.${ preset }`
+
+      settings.logger.log(`[${job.uid}] action-encode: input file ${inputPath}`)
+      settings.logger.log(`[${job.uid}] action-encode: output file ${outputPath}`)
+
+      await new Promise((resolve, reject) => {
+        const instance = spawn(binary, getPreset(inputPath, outputPath, preset, params));
+        instance.on('error', err => reject(new Error(`Error starting ffmpeg process: ${err}`)));
+        instance.stderr.on('data', (data) => settings.logger.log(`[${job.uid}] ${data.toString()}`));
+        instance.stdout.on('data', (data) => settings.debug && settings.logger.log(`[${job.uid}] ${data.toString()}`));
+        instance.on('close', (code) => {
+          if (code !== 0) reject(new Error('Error in child process (ffmpeg) code : ' + code))
+          else resolve()
+        });
+      });
+
+      if(type === 'prerender'){
+        job.assets
+          .filter(asset => asset.type === 'video' && path.parse(asset.src).name === inputFile.base)
+          .forEach(assetFile => assetFile.name = `${ inputFile.name }.${ preset }`);
+      }
+    }
+  } catch(e) {
+    console.log('index error', JSON.stringify(e, null, 2))
+    throw new Error('Error in action-encode module (ffmpeg) ' + e)
+  };
+}
+

--- a/packages/nexrender-action-encode-assets/package-lock.json
+++ b/packages/nexrender-action-encode-assets/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": "@nexrender/action-encode",
+  "version": "1.16.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-fetch-progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-progress/-/node-fetch-progress-1.0.2.tgz",
+      "integrity": "sha512-SHU7Ye0zcN/GHnjp2FMOLbJeJQ4ji68nicY6yF13VAmEZZKcbkjl3btkYmmtbVaL3gKoQxxba7WfTM6zOMUMyg==",
+      "requires": {
+        "bytes": "^3.0.0",
+        "date-fns": "^1.30.1",
+        "throttle-debounce": "^2.1.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "throttle-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
+      "integrity": "sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/packages/nexrender-action-encode-assets/package.json
+++ b/packages/nexrender-action-encode-assets/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@nexrender/action-encode",
+  "author": "inlife",
+  "version": "1.16.3",
+  "main": "index.js",
+  "ffmpeg-static": {
+    "version": "b4.2.2",
+    "url": "https://github.com/eugeneware/ffmpeg-static",
+    "_": "This is built-in ffmpeg-static dynamic dependency, visit url for more info."
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "date-fns": "^1.30.1",
+    "glob": "^7.1.6",
+    "node-fetch": "^2.6.0",
+    "node-fetch-progress": "^1.0.2"
+  }
+}

--- a/packages/nexrender-action-encode-assets/presets.js
+++ b/packages/nexrender-action-encode-assets/presets.js
@@ -1,0 +1,94 @@
+/* pars of snippet taken from https://github.com/xonecas/ffmpeg-node/blob/master/ffmpeg-node.js#L136 */
+module.exports = (input, output, preset, params) => {
+    switch(preset) {
+        case 'mp4':
+            params = Object.assign({}, {
+                '-i': input,
+                '-acodec': 'aac',
+                '-ab': '128k',
+                '-ar': '44100',
+                '-vcodec': 'libx264',
+                '-r': '25',
+                '-pix_fmt' : 'yuv420p',
+            }, params, {
+              '-y': output
+            });
+        break;
+
+        case 'ogg':
+            params = Object.assign({}, {
+                '-i': input,
+                '-acodec': 'libvorbis',
+                '-ab': '128k',
+                '-ar': '44100',
+                '-vcodec': 'libtheora',
+                '-r': '25',
+            }, params, {
+                '-y': output
+            });
+        break;
+
+        case 'webm':
+            params = Object.assign({}, {
+                '-i': input,
+                '-acodec': 'libvorbis',
+                '-ab': '128k',
+                '-ar': '44100',
+                '-vcodec': 'libvpx',
+                '-b': '614400',
+                '-aspect': '16:9',
+            }, params, {
+                '-y': output
+            });
+        break;
+
+        case 'mp3':
+            params = Object.assign({}, {
+                '-i': input,
+                '-acodec': 'libmp3lame',
+                '-ab': '128k',
+                '-ar': '44100',
+            }, params, {
+                '-y': output
+            });
+        break;
+
+        case 'm4a':
+            params = Object.assign({}, {
+                '-i': input,
+                '-acodec': 'aac',
+                '-ab': '64k',
+                '-ar': '44100',
+                '-strict': '-2',
+            }, params, {
+                '-y': output
+            });
+        break;
+
+        case 'gif':
+          params = Object.assign({}, {
+            '-i': input,
+            "-ss": '61.0',
+            "-t": '2.5',
+            "-filter_complex": `[0:v] fps=12,scale=480:-1,split [a][b];[a] palettegen [p];[b][p] paletteuse`,
+          }, params, {
+            '-y': output
+          });
+          break;
+
+        default:
+            params = Object.assign({}, {
+                '-i': input
+            }, params, {
+                '-y': output
+            });
+        break;
+    }
+
+
+    /* convert to plain array */
+    return Object.keys(params).reduce(
+        (cur, key) => cur.concat(key, params[key]), []
+    );
+}
+

--- a/packages/nexrender-action-encode-assets/readme.md
+++ b/packages/nexrender-action-encode-assets/readme.md
@@ -1,0 +1,115 @@
+# Action: Encode
+
+Encode all videos found by wildcard to a specified format using built-in ffmpeg utility. You don't need to have ffmpeg installed on your system.
+
+## Installation
+
+If you are using [binary](https://github.com/inlife/nexrender/releases) version of the nexrender,
+there is no need to install the module, it is **included** in the binary build.
+
+```
+npm i @nexrender/action-encode -g
+```
+
+## Usage
+
+When creating your render job provide this module as one of the `postrender` actions:
+
+```json
+// job.json
+{
+    "actions": {
+        "postrender": [
+            {
+                "module": "@nexrender/action-encode",
+                "output": "foobar.mp4",
+                "ffmpeg": "../ffmpeg",
+                "preset": "mp4",
+                "params": {"-vcodec": "libx264", "-r": 25}
+            }
+        ]
+    }
+}
+```
+
+## Information
+
+* `output` is a path on your system where result will be saved to, can be either relative or absulte path.
+* `input` optional argument, path or wildcard of the file(s) you want to encode, can be either relative or absulte path. Defaults to current job output video file.
+* `ffmpeg` optional argument, path to load the ffmpeg module from or save to if none found. can be absolute or ralative to workpath.
+* `preset` optional argument, if provided will be used as a preset for the renderer, if not, will take input directly from params
+* `params` optional argument, object containing additional params that will be provided to the ffmpeg binary
+
+## Presets
+
+There are a couple of default presets included with the build. You can provide `params` field to override any of the values there.
+
+### mp4
+
+```js
+{
+    '-acodec': 'aac',
+    '-ab': '128k',
+    '-ar': '44100',
+    '-vcodec': 'libx264',
+    '-r': '25',
+}
+```
+
+### ogg
+
+```js
+{
+    '-acodec': 'libvorbis',
+    '-ab': '128k',
+    '-ar': '44100',
+    '-vcodec': 'libtheora',
+    '-r': '25',
+}
+```
+
+### webm
+
+```js
+{
+    '-acodec': 'libvorbis',
+    '-ab': '128k',
+    '-ar': '44100',
+    '-vcodec': 'libvpx',
+    '-b': '614400',
+    '-aspect': '16:9',
+}
+```
+
+### mp3
+
+```js
+{
+    '-acodec': 'libmp3lame',
+    '-ab': '128k',
+    '-ar': '44100',
+
+}
+```
+
+### m4a
+
+```js
+{
+    '-acodec': 'aac',
+    '-ab': '64k',
+    '-ar': '44100',
+    '-strict': '-2',
+}
+```
+
+### gif
+
+```js
+{
+    '-i': input,
+    "-ss": '61.0',
+    "-t": '2.5',
+    "-filter_complex": `[0:v] fps=12,scale=480:-1,split [a][b];[a] palettegen [p];[b][p] paletteuse`,
+}
+```

--- a/packages/nexrender-action-encode-assets/test/index.js
+++ b/packages/nexrender-action-encode-assets/test/index.js
@@ -1,0 +1,2 @@
+// simple test of code syntax
+require('../index')

--- a/packages/nexrender-action-encode-assets/test/manual.js
+++ b/packages/nexrender-action-encode-assets/test/manual.js
@@ -1,0 +1,58 @@
+const encode = require('../index')
+// const { init, render } = require('../../nexrender-core/src')
+
+const job = {
+    uuid:"123",
+    template: {
+        src: 'file:///Users/inlife/Downloads/nexrender-boilerplate-master/assets/nm05ae12.aepx',
+        composition: 'main',
+        frameStart: 0,
+        frameEnd: 500,
+    },
+    assets: [],
+    actions: {
+        prerender: [
+          { module: __dirname + '/index.js',
+          }
+        ],
+        postrender: [
+            {
+                module: '@nexrender/action-encode',
+                output: 'output.mp4',
+                preset: 'mp4',
+            }
+        ]
+    },
+
+    onChange: (job, state) => console.log('testing onChange:', state),
+    onRenderProgress: (job, value) => console.log('testing onRenderProgress:', value)
+}
+
+const settings = {
+    logger: console,
+    skipCleanup: true,
+    debug: true,
+    workpath:"/Users/finnfrotscher/code/nexrender/packages/nexrender-action-encode-assets/test/tmp",
+}
+
+
+const options = {
+  preset:'mp4',
+  input:'*.mov',
+  // ffmpeg: "ffmpeg/",
+  params:{},
+  output:'',
+
+}
+
+const test  = async () => {
+  console.log('test', await encode(job, settings, options, 'prerender'))
+}
+test()
+
+
+// render(job, init(settings)).then(job => {
+//     console.log('finished rendering', job)
+// }).catch(err => {
+//     console.error(err)
+// })

--- a/packages/nexrender-action-encode-assets/test/myjob.json
+++ b/packages/nexrender-action-encode-assets/test/myjob.json
@@ -1,0 +1,50 @@
+{
+  "template": {
+    "src": "file:///Users/inlife/Downloads/nexrender-boilerplate-master/assets/nm05ae12.aepx",
+    "composition": "main",
+    "frameStart": 0,
+    "frameEnd": 200
+  },
+  "assets": [
+    {
+      "src": "file:///Users/inlife/Downloads/nexrender-boilerplate-master/assets/2016-aug-deep.jpg",
+      "type": "image",
+      "layerName": "background.jpg"
+    },
+    {
+      "src": "file:///Users/inlife/Downloads/nexrender-boilerplate-master/assets/nm.png",
+      "type": "image",
+      "layerName": "nm.png"
+    },
+    {
+      "src": "file:///Users/inlife/Downloads/nexrender-boilerplate-master/assets/deep_60s.mp3",
+      "type": "audio",
+      "layerName": "audio.mp3"
+    },
+    {
+      "type": "data",
+      "layerName": "artist",
+      "property": "position",
+      "value": [
+        0,
+        250
+      ],
+      "expression": "[5 * time, 250]"
+    },
+    {
+      "type": "data",
+      "layerName": "track name",
+      "property": "Source Text",
+      "value": "Привет мир"
+    }
+  ],
+  "actions": {
+    "postrender": [
+      {
+        "module": "@nexrender/action-encode",
+        "output": "output.mp4",
+        "preset": "mp4"
+      }
+    ]
+  }
+}

--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -134,6 +134,17 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             });
         break;
 
+        case 'gif':
+          params = Object.assign({}, {
+            '-i': input,
+            "-ss": '61.0',
+            "-t": '2.5',
+            "-filter_complex": `[0:v] fps=12,scale=480:-1,split [a][b];[a] palettegen [p];[b][p] paletteuse`,
+          }, params, {
+            '-y': output
+          });
+          break;
+
         default:
             params = Object.assign({}, {
                 '-i': input

--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -5,12 +5,19 @@ const fetch   = require('node-fetch')
 const {spawn} = require('child_process')
 const nfp     = require('node-fetch-progress')
 
-const getBinary = (job, settings) => {
+const getBinary = (job, settings, {params}) => {
     return new Promise((resolve, reject) => {
         const {version} = pkg['ffmpeg-static']
-        const filename = `ffmpeg-${version}${process.platform == 'win32' ? '.exe' : ''}`
         const fileurl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${version}/${process.platform}-x64`
-        const output = path.join(settings.workpath, filename)
+        let output;
+
+        if (params.ffmpeg.path){
+          output = params.ffmpeg.path;
+        } else {
+          const filename = `ffmpeg-${version}${process.platform == 'win32' ? '.exe' : ''}`
+          const fileroot = params.ffmpeg.root || settings.workpath
+          output = path.join(fileroot, filename)
+        }
 
         if (fs.existsSync(output)) {
             settings.logger.log(`> using an existing ffmpeg binary ${version} at: ${output}`)
@@ -147,7 +154,7 @@ module.exports = (job, settings, options, type) => {
 
     return new Promise((resolve, reject) => {
         const params = constructParams(job, settings, options);
-        const binary = getBinary(job, settings).then(binary => {
+        const binary = getBinary(job, settings, options).then(binary => {
             const instance = spawn(binary, params);
 
             instance.on('error', err => reject(new Error(`Error starting ffmpeg process: ${err}`)));

--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -6,7 +6,6 @@ const uri2path = require('file-uri-to-path')
 const data2buf = require('data-uri-to-buffer')
 const {expandEnvironmentVariables} = require('../helpers/path')
 
-// TODO: redeuce dep size
 const requireg = require('requireg')
 
 const download = (job, settings, asset) => {


### PR DESCRIPTION
Hi, 
i need to encode videos before pushing them into after effects because some formats are rendered with issues under mac.
for this, i copied your module and changed the input path to a possible wildcard/regex. 
now, any file that matches the wildcard will be encoded to the desired format.

in the process i added a preset gifs. check the commit log to see the implementation reference. i havent  tested it tbh. but this is what it could  look like.
also its now possible to pass in a `ffmpeg` path. 
i added both to the docs/readme.

its not production code. 
known issues:
if the surrounding folder of the ffmpeg or the asset destination path is missing, the process dies.
the original use for the module can not be fascilitated, sind the `ouput` parameter is not acutally used to name the output files. reason: its now potentially multiple files instead of one. easy fix:  check how many files where matched by the wildcard, and if its only one -> apply the name from `output` else the current pattern

best,
finn