### PR TITLE
Update download.js - changing error from `url` (a dependancy module) to `uri`

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -61,14 +61,14 @@ const download = (job, settings, asset) => {
             /* TODO: maybe move to external package ?? */
             const src = decodeURI(asset.src) === asset.src ? encodeURI(asset.src): asset.src
             return fetch(src, asset.params || {})
-                .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {uri, error: res.error}}))
+                .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {src, error: res.error}}))
                 .then(res => {
                     const stream = fs.createWriteStream(asset.dest)
                     let timer
 
                     return new Promise((resolve, reject) => {
                         const errorHandler = (error) => {
-                            reject(new Error({reason: 'Unable to download file', meta: {uri, error}}))
+                            reject(new Error({reason: 'Unable to download file', meta: {src, error}}))
                         };
 
                         res.body

--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -61,14 +61,14 @@ const download = (job, settings, asset) => {
             /* TODO: maybe move to external package ?? */
             const src = decodeURI(asset.src) === asset.src ? encodeURI(asset.src): asset.src
             return fetch(src, asset.params || {})
-                .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {url, error: res.error}}))
+                .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {uri, error: res.error}}))
                 .then(res => {
                     const stream = fs.createWriteStream(asset.dest)
                     let timer
 
                     return new Promise((resolve, reject) => {
                         const errorHandler = (error) => {
-                            reject(new Error({reason: 'Unable to download file', meta: {url, error}}))
+                            reject(new Error({reason: 'Unable to download file', meta: {uri, error}}))
                         };
 
                         res.body


### PR DESCRIPTION
changing error from `url` (a dependancy module) to `uri` (although not sure if `src` would be better?)