### PR TITLE
Feat: WSL Support & .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore everything:
+/*

--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -15,6 +15,7 @@ const args = arg({
     '--file':       String,
     '--binary':     String,
     '--workpath':   String,
+    '--wsl-map':    String,
 
     '--stop-on-error':  String,
 
@@ -36,6 +37,7 @@ const args = arg({
     '-f':           '--file',
     '-b':           '--binary',
     '-w':           '--workpath',
+    '-m':           '--wsl-map',
 });
 
 let serverHost = 'http://localhost:3000';
@@ -73,6 +75,7 @@ if (args['--help']) {
 
       -w, --workpath {underline absolute_path}          manually override path to the working directory
                                             by default nexrender is using os tmpdir/nexrender folder
+      -m, --wsl-map                       drive letter of your WSL mapping in Windows
 
   {bold ADVANCED OPTIONS}
 
@@ -145,6 +148,7 @@ opt('reuse',                '--reuse');
 opt('stopOnError',          '--stop-on-error');
 opt('maxMemoryPercent',     '--max-memory-percent');
 opt('imageCachePercent',    '--image-cache-percent');
+opt('wslMap',               '--wsl-map');
 
 /* convert string arugument into a boolean */
 settings['stopOnError'] = settings['stopOnError'] == 'true';

--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -37,6 +37,29 @@ const defaultPaths = {
         'C:\\Program Files\\Adobe\\Adobe After Effects 2020\\Support Files',
         'C:\\Program Files\\Adobe\\Adobe After Effects 2021\\Support Files',
     ],
+    wsl: [
+        '/mnt/c/Program Files/Adobe/After Effects CC',
+        '/mnt/c/Program Files/Adobe/After Effects CC/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects CC 2015/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects CC 2016/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects CC 2017/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects CC 2018/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects CC 2019/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects CC 2020/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects 2020/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects 2021/Support Files',
+
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC 2015/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC 2016/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC 2017/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC 2018/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC 2019/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects CC 2020/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects 2020/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects 2021/Support Files',
+    ],
 }
 
 /**
@@ -46,13 +69,15 @@ const defaultPaths = {
  * @return {String|null}
  */
 module.exports = settings => {
-    const platform = os.platform()
+    let platform = os.platform()
+
+    if (settings.wsl) platform = 'wsl'
 
     if (!defaultPaths.hasOwnProperty(platform)) {
         return null;
     }
 
-    const binary  = 'aerender' + (platform === 'win32' ? '.exe' : '' )
+    const binary  = 'aerender' + (platform === 'win32' || platform === 'wsl' ? '.exe' : '' )
     const results = defaultPaths[platform]
         .map(folderPath => path.join(folderPath, binary))
         .filter(binaryPath => fs.existsSync(binaryPath))

--- a/packages/nexrender-core/src/helpers/path.js
+++ b/packages/nexrender-core/src/helpers/path.js
@@ -23,6 +23,18 @@ function expandEnvironmentVariables(pathString) {
     }, pathString);
 }
 
+let checkForWSL = (pathString, settings) => {
+    if (!settings.wsl) return pathString
+
+    return pathString.match(/\/mnt\/[a-zA-Z]\//)
+        ? pathString.replace(
+              /\/mnt\/[a-zA-Z]\//,
+              `${pathString.split('/')[2].toUpperCase()}:/`
+          )
+        : `${settings.wslMap}:${pathString}`
+}
+
 module.exports = {
-    expandEnvironmentVariables: expandEnvironmentVariables
+    expandEnvironmentVariables: expandEnvironmentVariables,
+    checkForWSL
 };

--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -37,6 +37,12 @@ const init = (settings) => {
     settings = Object.assign({}, settings);
     settings.logger = settings.logger || console;
 
+    // check for WSL
+    settings.wsl =
+        os.platform() === 'linux' && os.release().match('microsoft')
+            ? true
+            : false
+
     const binaryAuto = autofind(settings);
     const binaryUser = settings.binary && fs.existsSync(settings.binary) ? settings.binary : null;
 
@@ -62,6 +68,7 @@ const init = (settings) => {
         multiFrames: false,
         maxMemoryPercent: undefined,
         imageCachePercent: undefined,
+        wslMap: undefined,
 
         __initialized: true,
     }, settings, {
@@ -72,6 +79,11 @@ const init = (settings) => {
     if (!path.isAbsolute(settings.workpath)) {
         settings.workpath = path.join(process.cwd(), settings.workpath);
     }
+
+    // if WSL, ask user to define Mapping
+    if (settings.wsl && !settings.wslMap)
+        throw new Error('WSL detected: provide your WSL drive map; ie. "Z"')
+
 
     // add license helper
     if (settings.addLicense) {

--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const {spawn} = require('child_process')
-const {expandEnvironmentVariables} = require('../helpers/path')
+const {expandEnvironmentVariables, checkForWSL} = require('../helpers/path')
 
 const progressRegex = /([\d]{1,2}:[\d]{2}:[\d]{2}:[\d]{2})\s+(\(\d+\))/gi;
 const durationRegex = /Duration:\s+([\d]{1,2}:[\d]{2}:[\d]{2}:[\d]{2})/gi;
@@ -25,11 +25,17 @@ module.exports = (job, settings) => {
     // create container for our parameters
     let params = [];
     let outputFile = expandEnvironmentVariables(job.output)
+    let projectFile = expandEnvironmentVariables(job.template.dest)
+
+    outputFileAE = checkForWSL(outputFile, settings)
+    projectFile = checkForWSL(projectFile, settings)
+    let jobScriptFile = checkForWSL(job.scriptfile, settings)
+
 
     // setup parameters
-    params.push('-project', expandEnvironmentVariables(job.template.dest));
+    params.push('-project', projectFile);
     params.push('-comp', job.template.composition);
-    params.push('-output', outputFile);
+    params.push('-output', outputFileAE);
 
     if (!settings.skipRender){
 
@@ -44,7 +50,7 @@ module.exports = (job, settings) => {
         option(params, '-e', 1);
     }
 
-    option(params, '-r', job.scriptfile);
+    option(params, '-r', jobScriptFile);
 
     if (!settings.skipRender && settings.multiFrames) params.push('-mp');
     if (settings.reuse) params.push('-reuse');

--- a/packages/nexrender-core/src/tasks/script.js
+++ b/packages/nexrender-core/src/tasks/script.js
@@ -2,6 +2,7 @@ const fs     = require('fs')
 const path   = require('path')
 const script = require('../assets/nexrender.jsx')
 const matchAll = require('match-all')
+const { checkForWSL } = require('../helpers/path')
 
 /* helpers */
 const escape = str => {
@@ -30,9 +31,9 @@ const partsOfKeypath = (keypath) => {
 }
 
 /* scripting wrappers */
-const wrapFootage = ({ dest, ...asset }) => (`(function() {
+const wrapFootage = ({ dest, ...asset }, settings) => (`(function() {
     ${selectLayers(asset, `function(layer) {
-        nexrender.replaceFootage(layer, '${dest.replace(/\\/g, "\\\\")}')
+        nexrender.replaceFootage(layer, '${checkForWSL(dest.replace(/\\/g, "\\\\"), settings)}')
     }`)}
 })();\n`)
 
@@ -475,7 +476,7 @@ module.exports = (job, settings) => {
             case 'video':
             case 'audio':
             case 'image':
-                data.push(wrapFootage(asset));
+                data.push(wrapFootage(asset, settings));
                 break;
 
             case 'data':

--- a/packages/nexrender-core/test/manual-win-wsl.js
+++ b/packages/nexrender-core/test/manual-win-wsl.js
@@ -1,0 +1,18 @@
+const { init, render } = require('../src');
+const job = require('./mywsljob.json');
+
+const settings = {
+    logger: console,
+    skipCleanup: true,
+    debug: true,
+    wslMap: 'Z',
+    // workpath: '/mnt/d/Downloads/tmp/nexrender'
+}
+
+// console.log(JSON.stringify(job))
+
+render(job, init(settings)).then(job => {
+    console.log('finished rendering', job)
+}).catch(err => {
+    console.error(err)
+})

--- a/packages/nexrender-core/test/mywsljob.json
+++ b/packages/nexrender-core/test/mywsljob.json
@@ -1,0 +1,49 @@
+{
+    "template": {
+        "src": "file:///mnt/d/Downloads/nexrender-boilerplate-master/assets/nm05ae12.aepx",
+        "composition": "main",
+
+        "frameStart": 0,
+        "frameEnd": 500
+    },
+    "assets": [
+        {
+            "src": "file:///mnt/d/Downloads/nexrender-boilerplate-master/assets/2016-aug-deep.jpg",
+            "type": "image",
+            "layerName": "background.jpg"
+        },
+        {
+            "src": "file:///mnt/d/Downloads/nexrender-boilerplate-master/assets/nm.png",
+            "type": "image",
+            "layerName": "nm.png"
+        },
+        {
+            "src": "file:///mnt/d/Downloads/nexrender-boilerplate-master/assets/deep_60s.mp3",
+            "type": "audio",
+            "useOriginal": true,
+            "layerName": "audio.mp3"
+        },
+        {
+            "type": "data",
+            "layerName": "artist",
+            "property": "position",
+            "value": [0, 250],
+            "expression": [50, 250]
+        },
+        {
+            "type": "data",
+            "layerName": "track name",
+            "property": "Source Text",
+            "value": "Test"
+        }
+    ],
+    "actions": {
+        "postrender": [
+            {
+                "module": "@nexrender/action-encode",
+                "output": "output.mp4",
+                "preset": "mp4"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds support for `WSL (Windows Subsystem for Linux)` and `.prettierignore`.

### Overview

Currently `nexrender` does not support users who are using `WSL`. This PR adds support for these users with little change to the base code.

>Init Issue [Is it possible to run Nexrender from WSL2?](https://github.com/inlife/nexrender/issues/422)

Due to issues with my last PR I have also added in a `.prettierignore config` in order to tell prettier to not format.  

### Testing
Tested on `Windows` and `WSL`.

Will need to be tested on `macOS`, though I do no believe it should have affected it.


### Feedback

Feedback welcomed.