### PR TITLE
Improve WSL detection

### DIFF
--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -39,7 +39,7 @@ const init = (settings) => {
 
     // check for WSL
     settings.wsl =
-    os.platform() === 'linux' && os.release().match(/microsoft/i)
+        os.platform() === 'linux' && os.release().match(/microsoft/i)
             ? true
             : false
 

--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -39,7 +39,7 @@ const init = (settings) => {
 
     // check for WSL
     settings.wsl =
-        os.platform() === 'linux' && os.release().match('microsoft')
+    os.platform() === 'linux' && os.release().match(/microsoft/i)
             ? true
             : false
 


### PR DESCRIPTION
Current WSL detection works with a case-sensitive match on 'microsoft', which means it fails when your OS release string contains 'Microsoft' instead.

<img width="479" alt="image" src="https://user-images.githubusercontent.com/2266809/90254420-fce07e00-de42-11ea-9b6d-4987c60a25e7.png">

This resolves that issue.