### PR TITLE
Callbacks for action-encode and action-upload

### DIFF
--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -3,7 +3,10 @@ const path     = require('path')
 const {name}   = require('./package.json')
 const requireg = require('requireg')
 
-module.exports = (job, settings, { input, provider, params }, type) => {
+module.exports = (job, settings, { input, provider, params, ...options }, type) => {
+    let onProgress;
+    let onComplete;
+
     if (type != 'postrender') {
         throw new Error(`Action ${name} can be only run in postrender mode, you provided: ${type}.`)
     }
@@ -18,20 +21,28 @@ module.exports = (job, settings, { input, provider, params }, type) => {
     /* fill absolute/relative paths */
     if (!path.isAbsolute(input)) input = path.join(job.workpath, input);
 
+    if (options.hasOwnProperty('onProgress') && typeof options['onProgress'] == 'function') {
+        onProgress = (job, progress) => options.onProgress(job, progress);
+    }
+
+    if (options.hasOwnProperty('onComplete') && typeof options['onComplete'] == 'function') {
+        onComplete = (job) => options.onComplete(job);
+    }
+
     settings.logger.log(`[${job.uid}] starting action-upload action`)
 
     let requirePackage = ''
     try {
         /* try requiring official providers */
         requirePackage = `@nexrender/provider-${provider}`
-        return requireg('@nexrender/provider-' + provider).upload(job, settings, input, params || {});
+        return requireg(requirePackage).upload(job, settings, input, params || {}, onProgress, onComplete);
 
     } catch (e) {
         if (e.message.indexOf('Could not require module') !== -1) {
             try{
                 /* try requiring custom providers */
                 requirePackage = provider
-                return requireg(provider).upload(job, settings, input, params || {});
+                return requireg(requirePackage).upload(job, settings, input, params || {}, onProgress, onComplete);
 
             } catch(e) {
                 if (e.message.indexOf('Could not require module') !== -1) {

--- a/packages/nexrender-action-upload/index.js
+++ b/packages/nexrender-action-upload/index.js
@@ -26,7 +26,7 @@ module.exports = (job, settings, { input, provider, params, ...options }, type) 
     }
 
     if (options.hasOwnProperty('onComplete') && typeof options['onComplete'] == 'function') {
-        onComplete = (job) => options.onComplete(job);
+        onComplete = (job, file) => options.onComplete(job, file);
     }
 
     settings.logger.log(`[${job.uid}] starting action-upload action`)

--- a/packages/nexrender-provider-s3/src/index.js
+++ b/packages/nexrender-provider-s3/src/index.js
@@ -83,11 +83,11 @@ const upload = (job, settings, src, params, onProgress, onComplete) => {
         settings.logger.log(`[${job.uid}] action-upload: upload progress ${progress}%...`)
     }
 
-    const onUploadComplete = () => {
+    const onUploadComplete = (file) => {
         if (typeof onComplete == 'function') {
-            onComplete(job);
+            onComplete(job, file);
         }
-        settings.logger.log(`[${job.uid}] action-upload: upload complete`)
+        settings.logger.log(`[${job.uid}] action-upload: upload complete: ${file}`)
     }
 
     const output = `https://s3-${params.region}.amazonaws.com/${params.bucket}/${params.key}`
@@ -111,7 +111,7 @@ const upload = (job, settings, src, params, onProgress, onComplete) => {
                 }
                 else
                 {
-                    onUploadComplete()
+                    onUploadComplete(data.Location)
                     resolve()
                 }
             })


### PR DESCRIPTION
Initial PR to add the ability for action-encode and action-upload to specify and use callbacks (onProgress, onComplete). Eventually it would be good to be able to pass this back up to the api so we can report progress on other steps of the pipeline not just rendering.

eg
```javascript
        postrender: [
            {
                module: '@nexrender/action-encode',
                output: 'output.mp4',
                preset: 'mp4',
                onProgress: (job, value) => do something
                onComplete: (job, value) => do something
            }
        ]
```

Thoughts?