### PR TITLE
added /health endpoint that always returns 200 without secret

### DIFF
--- a/packages/nexrender-server/README.md
+++ b/packages/nexrender-server/README.md
@@ -100,3 +100,8 @@ Removes provided job from the server.
 An internall method, used by worker to fetch a random job from the list, and start rendering.
 Probably should not be used by users, unless they know what are they doing.
 
+### GET `/api/v1/health`
+
+Can serve as the health check for the service, does not require the secret header to be passed.
+Returns 200 always.
+

--- a/packages/nexrender-server/src/index.js
+++ b/packages/nexrender-server/src/index.js
@@ -27,6 +27,10 @@ const handler = secret => {
             return send(res, 200, 'ok');
         }
 
+        if (req.method == 'GET' && req.url == '/api/v1/health') {
+            return send(res, 200, 'ok');
+        }
+
         return withSecret(secret, subhandler)(req, res)
     })
 }


### PR DESCRIPTION
If you need to deploy `nexrender-server` behind the load balancer, then you need to define a valid health check. Health checks must usually return `200`.. 

Currently we have a problem that we want to place it behind the Kubernetes ingress with using the secret of course.. However Kubernetes still does not have a possibility to define a health check that includes a header value from secrets.. Thus we cannot set `nexrender-secret` header and create a health check (we could, but then we would expose secret in the deployment files)..

I created this small patch, that exposes `/health` which can be accessed without the `nexrender-secret` header. Simply returns 200.

Let me know if you want me to do anything else. Hope this gets in soon..
