### PR TITLE
Fix typo (Apllications)

### DIFF
--- a/packages/nexrender-core/readme.md
+++ b/packages/nexrender-core/readme.md
@@ -32,7 +32,7 @@ const { render } = require('@nexrender/core')
 const main = async () => {
     const result = await render(/*myJobJson*/, {
         workpath: '/Users/myname/.nexrender/',
-        binary: '/Users/mynames/Apllications/aerender',
+        binary: '/Users/mynames/Applications/aerender',
         skipCleanup: true,
         addLicense: false,
         debug: true,


### PR DESCRIPTION
I noticed a small typo in a readme, it read "Apllications" instead of "Applications".