### PR TITLE
add the cacheControl meta-data in the gs provder

### DIFF
--- a/packages/nexrender-action-upload/readme.md
+++ b/packages/nexrender-action-upload/readme.md
@@ -91,6 +91,7 @@ The upload params are given as part of the action:
 * `bucket` (required)
 * `item` (required)
 * `contentType` (optional)
+* `cacheControl` (optional)
 
 Example:
 
@@ -106,7 +107,8 @@ Example:
                 "params": {
                     "bucket": "name-of-your-bucket",
                     "item": "folder/uploaded.mp4",
-                    "contentType": "video/mp4"
+                    "contentType": "video/mp4",
+                    "cacheControl": "public, max-age=3600"
                 }
             }
         ]

--- a/packages/nexrender-provider-gs/README.md
+++ b/packages/nexrender-provider-gs/README.md
@@ -48,6 +48,7 @@ Basic params info:
 * `bucket` required argument, the GCS bucket
 * `item` required argument, the item ID
 * `contentType` optional argument, the content-type of the upload, which will be set as metadata on
+* `cacheControl` optional argument, the cache-control of the upload, which will be set as metadata on
   the bucket item
 
 Example:
@@ -63,7 +64,8 @@ Example:
                 "params": {
                     "bucket": "name-of-your-bucket",
                     "item": "folder/output.mp4",
-                    "contentType": "video/mp4"
+                    "contentType": "video/mp4",
+                    "cacheControl": "public, max-age=3600"
                 }
             }
         ]

--- a/packages/nexrender-provider-gs/src/index.js
+++ b/packages/nexrender-provider-gs/src/index.js
@@ -48,10 +48,19 @@ const upload = (job, settings, src, params) => {
     return new Promise((resolve, reject) => {
         const bucket = storage.bucket(params.bucket)
         const file = bucket.file(params.item)
-        const options = {}
+        const options = {
+            metadata: {}
+        }
         if (params.contentType) {
             options.metadata = {
+                ...options.metadata,
                 contentType: params.contentType
+            }
+        }
+        if (params.cacheControl) {
+            options.metadata = {
+                ...options.metadata,
+                cacheControl: params.cacheControl
             }
         }
         const in_stream = fs.createReadStream(src)


### PR DESCRIPTION
GS offers to set a `Cache-Control` for each uploaded object. As we are uploading are videos, they are usually immutable and huge in size.. With `cacheControl` option we can set way longer cache props, thus saving on the transfer sizes, at least for the users that open the video in the browser.. I think this PR is thus valid and helpful..

I initialized the empty metadata if no optional params are passed, I guess this should be fine..

Let me know if anything should be improved..