### PR TITLE
Add stats about rendering times

### DIFF
--- a/packages/nexrender-action-copy/index.js
+++ b/packages/nexrender-action-copy/index.js
@@ -15,7 +15,7 @@ module.exports = (job, settings, { input, output }, type) => {
     if (!path.isAbsolute(output)) output = path.join(job.workpath, output);
 
     /* output is a directory, save to input filename */
-    if (path.dirname(output) === output) {
+    if (fs.existsSync(output) && fs.lstatSync(output).isDirectory()) {
         output = path.join(output, path.basename(input));
     }
 

--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -190,6 +190,9 @@ module.exports = (job, settings, options, type) => {
     return new Promise((resolve, reject) => {
         const params = constructParams(job, settings, options);
         const binary = getBinary(job, settings).then(binary => {
+            if (settings.debug) {
+                settings.logger.log(`[${job.uid}] spawning ffmpeg process: ${binary} ${params.join(' ')}`);
+            }
             const instance = spawn(binary, params);
             let totalDuration = 0
 

--- a/packages/nexrender-server/src/helpers/database.js
+++ b/packages/nexrender-server/src/helpers/database.js
@@ -38,10 +38,8 @@ const fetch = uid => uid ? data[indexOf(uid)] : data
 const insert = entry => {
     const now = new Date()
 
-    Object.assign({}, entry, {
-        updatedAt: now,
-        createdAt: now
-    })
+    entry.updatedAt = now
+    entry.createdAt = now
 
     data.push(entry);
     setImmediate(save);

--- a/packages/nexrender-server/src/routes/jobs-create.js
+++ b/packages/nexrender-server/src/routes/jobs-create.js
@@ -7,6 +7,7 @@ module.exports = async (req, res) => {
     const data = await json(req, {limit: "100mb"})
     const job  = create(data); {
         job.state = 'queued';
+        job.creator = req.socket.remoteAddress
     }
 
     console.log(`creating new job ${job.uid}`)

--- a/packages/nexrender-server/src/routes/jobs-pickup.js
+++ b/packages/nexrender-server/src/routes/jobs-pickup.js
@@ -25,5 +25,5 @@ module.exports = async (req, res) => {
     }
 
     /* update the job locally, and send it to the worker */
-    send(res, 200, update(job.uid, { state: 'picked' }))
+    send(res, 200, update(job.uid, { state: 'picked', executor: req.socket.remoteAddress }))
 }

--- a/packages/nexrender-types/job.js
+++ b/packages/nexrender-types/job.js
@@ -94,7 +94,20 @@ const validate = job => {
  * @param  {Object} job
  * @return {Object} {uid: string, state: string, type: string, renderProgress: number, error: string}
  */
-const getRenderingStatus = job => ({uid: job.uid, state: job.state, type: job.type, renderProgress: job.renderProgress || 0, error: job.error || null})
+const getRenderingStatus = job => ({
+    uid: job.uid,
+    state: job.state,
+    type: job.type,
+    renderProgress: job.renderProgress || 0,
+    error: job.error || null,
+    createdAt: job.createdAt || null,
+    updatedAt: job.updatedAt || null,
+    startedAt: job.startedAt || null,
+    finishedAt: job.finishedAt || null,
+    errorAt: job.errorAt || null,
+    jobCreator: job.creator,
+    jobExecutor: job.executor || null
+})
 
 module.exports = {
     create,

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -49,6 +49,7 @@ const start = async (host, secret, settings) => {
     do {
         let job = await nextJob(client, settings); {
             job.state = 'started';
+            job.startedAt = new Date()
         }
 
         try {
@@ -75,12 +76,14 @@ const start = async (host, secret, settings) => {
 
             job = await render(job, settings); {
                 job.state = 'finished';
+                job.finishedAt = new Date()
             }
 
             await client.updateJob(job.uid, getRenderingStatus(job))
         } catch (err) {
             job.state = 'error';
             job.error = err;
+            job.errorAt = new Date()
 
             await client.updateJob(job.uid, getRenderingStatus(job));
 


### PR DESCRIPTION
Adds a few fields to entry items on the database:
* createdAt (already existed but wasnt being populated correctly)
* startedAt: the time the worker started picked the job up for rendering
* finishedAt: the time the worker finished processing
* errorAt: time at which the worker encountered an error processing
* jobCreator: remote ip address that submitted the job
* jobExecutor: remote ip address of the worker that picked up the job for processing

Also adds a few QOL:
* print ffmpeg command when --debug flag is set
* fix checking if output is a directory (checking names is unreliable)