### PR TITLE
debug should imply verbosity

### DIFF
--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -163,6 +163,9 @@ opt('ae-params',            '--aerender-parameter');
 /* convert string arugument into a boolean */
 settings['stopOnError'] = settings['stopOnError'] == 'true';
 
+/* debug implies verbose */
+settings.verbose = settings.debug;
+
 if (settings['no-license']) {
     settings.addLicense = false;
     delete settings['no-license'];


### PR DESCRIPTION
Hi Vladyslav,

this is just a one line improvement but one that has helped us a lot.
The nexrender-cli does not have an argument to turn verbose output on.
But it has the `--debug` option and this change makes that option turn on verbosity as well.
I guess that this is a sensible choice since you will want to see the verbose output when debugging anyway.

Kind regards
Bernd