### PR TITLE
Bug fix: Remove extra period from randomly generated name

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -26,7 +26,7 @@ const download = (job, settings, asset) => {
 
         /* prevent same name file collisions */
         if (fs.existsSync(path.join(job.workpath, destName))) {
-            destName = Math.random().toString(36).substring(2) + '.' + path.extname(asset.src);
+            destName = Math.random().toString(36).substring(2) + path.extname(asset.src);
         }
     }
 


### PR DESCRIPTION
`path.extname` returns the extension including the period symbol, or an empty string when no extension is present. Currently this code leads to names like `abc123..aepx` being generated.

https://nodejs.org/api/path.html#path_path_extname_path

This change just removes the extra period from the constructed string.