### PR TITLE
Feature: add more credential config options to S3 provider

### DIFF
--- a/packages/nexrender-provider-s3/readme.md
+++ b/packages/nexrender-provider-s3/readme.md
@@ -10,7 +10,13 @@ Refer to [aws/aws-sdk-js](https://github.com/aws/aws-sdk-js) for information reg
 npm i @nexrender/provider-s3 -g
 ```
 
-Make sure to define 2 envirnonment variables for this module to work:
+## Authentication
+
+Providing credentials can be done in the following ways
+
+### Environment variables
+
+You can provide either an access key ID and a secret key, or an AWS profile name that's configured in ~/.aws/credentials
 
 You can do it in your current console session
 
@@ -18,15 +24,27 @@ You can do it in your current console session
 ; windows
 set AWS_ACCESS_KEY="YOUR_ACCESS_KEY"
 set AWS_SECRET_KEY="YOUR_SECRET_KEY"
+; or
+
+set AWS_PROFILE="YOUR_PROFILE_NAME"
 ```
 
 ```sh
 # unix
 export AWS_ACCESS_KEY="YOUR_ACCESS_KEY"
 export AWS_SECRET_KEY="YOUR_SECRET_KEY"
+# or
+export AWS_PROFILE="YOUR_PROFILE_NAME"
 ```
 
-Or using any other way that suitable for you, that you can find.
+### Credentials parameter
+
+For both downloads and uploads you can provide a credentials object with either an access key ID and a secret key, or an AWS profile name that's configured in ~/.aws/credentials.
+For downloads, add the credentials object to the asset objects. For uploads, add it to the action params.
+
+* `credentials.profile` optional argument, a specific AWS credentials profile to use for authentication.
+* `credentials.accessKeyId` optional argument, a specific accessKeyId to use for authentication. Requires `secretAccessKey` to also be specified.
+* `credentials.secretAccessKey` optional argument, a specific secretAccessKey to use for authentication. Requires `accessKeyId` to also be specified.
 
 ## Usage (download)
 
@@ -45,7 +63,11 @@ Refer to [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-javascript/
         {
             "src": "s3://myotherbucket.s3.amazonaws.com/audio.mp3",
             "type": "audio",
-            "layerName": "theme.mp3"
+            "layerName": "theme.mp3",
+            "credentials": {
+                "accessKeyId": "YOUR_ACCESS_KEY",
+                "secretAccessKey": "YOUR_SECRET_KEY"
+	    }
         }
     ]
 }
@@ -59,6 +81,9 @@ s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]
 
 If region is not provided, the default region of `us-east-1` will be used.
 
+When you want to overwrite the default AWS authentication used for specific assets, you can specify the credentials parameter:
+
+
 ## Usage (upload)
 
 Upload via FTP can be done using [@nexrender/action-upload](../nexrender-action-upload)
@@ -69,6 +94,7 @@ Basic params info:
 * `bucket` required argument, the S3 bucket
 * `key` required argument, the object key
 * `acl` required argument, the ACL
+* `credentials`  optional argument, see: [credentials parameter](#credentials-parameter)
 
 Example:
 
@@ -84,7 +110,10 @@ Example:
                     "region": "us-east-1",
                     "bucket": "name-of-your-bucket",
                     "key": "folder/output.mp4",
-                    "acl": "public-read"
+                    "acl": "public-read",
+                    "credentials": {
+                        "profile": "YOUR_PROFILE_NAME"
+                    }
                 }
             }
         ]

--- a/packages/nexrender-provider-s3/readme.md
+++ b/packages/nexrender-provider-s3/readme.md
@@ -14,6 +14,14 @@ npm i @nexrender/provider-s3 -g
 
 Providing credentials can be done in the following ways
 
+### Credentials parameter
+
+For both downloads and uploads you can provide a credentials object to the params with either an access key ID and a secret key, or an AWS profile name that's configured in ~/.aws/credentials
+
+* `credentials.profile` optional argument, a specific AWS credentials profile to use for authentication.
+* `credentials.accessKeyId` optional argument, a specific accessKeyId to use for authentication. Requires `secretAccessKey` to also be specified.
+* `credentials.secretAccessKey` optional argument, a specific secretAccessKey to use for authentication. Requires `accessKeyId` to also be specified.
+
 ### Environment variables
 
 You can provide either an access key ID and a secret key, or an AWS profile name that's configured in ~/.aws/credentials
@@ -37,18 +45,9 @@ export AWS_SECRET_KEY="YOUR_SECRET_KEY"
 export AWS_PROFILE="YOUR_PROFILE_NAME"
 ```
 
-### Credentials parameter
-
-For both downloads and uploads you can provide a credentials object with either an access key ID and a secret key, or an AWS profile name that's configured in ~/.aws/credentials.
-For downloads, add the credentials object to the asset objects. For uploads, add it to the action params.
-
-* `credentials.profile` optional argument, a specific AWS credentials profile to use for authentication.
-* `credentials.accessKeyId` optional argument, a specific accessKeyId to use for authentication. Requires `secretAccessKey` to also be specified.
-* `credentials.secretAccessKey` optional argument, a specific secretAccessKey to use for authentication. Requires `accessKeyId` to also be specified.
-
 ## Usage (download)
 
-To download assets from an S3 you would need to specify relevant information for every asset:
+To download assets from an S3 bucket you would need to specify relevant information for every asset:
 
 Refer to [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) for information on setting credentials.
 
@@ -64,10 +63,12 @@ Refer to [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-javascript/
             "src": "s3://myotherbucket.s3.amazonaws.com/audio.mp3",
             "type": "audio",
             "layerName": "theme.mp3",
-            "credentials": {
-                "accessKeyId": "YOUR_ACCESS_KEY",
-                "secretAccessKey": "YOUR_SECRET_KEY"
-	    }
+            "params": {
+                "credentials": {
+                    "accessKeyId": "YOUR_ACCESS_KEY",
+                    "secretAccessKey": "YOUR_SECRET_KEY"
+                }
+            }
         }
     ]
 }
@@ -80,9 +81,6 @@ s3://[BUCKET].s3.[REGION].amazonaws.com/[KEY]
 ```
 
 If region is not provided, the default region of `us-east-1` will be used.
-
-When you want to overwrite the default AWS authentication used for specific assets, you can specify the credentials parameter:
-
 
 ## Usage (upload)
 

--- a/packages/nexrender-provider-s3/src/index.js
+++ b/packages/nexrender-provider-s3/src/index.js
@@ -28,7 +28,7 @@ const s3instanceWithRegion = (region, credentials) => {
     if (!regions.hasOwnProperty(key)) {
         const options = { region: region }
 
-	if (credentials) options.credentials = credentials
+        if (credentials) options.credentials = credentials
 
         regions[key] = new S3(options)
     }
@@ -42,7 +42,7 @@ const s3instanceWithEndpoint = (endpoint, credentials) => {
     if (!endpoints.hasOwnProperty(key)) {
         const options = { endpoint: endpoint }
 
-	if (credentials) options.credentials = credentials
+        if (credentials) options.credentials = credentials
 
         endpoints[key] = new S3(options)
     }
@@ -76,7 +76,7 @@ const download = (job, settings, src, dest, params, type) => {
             Key: parsed.key,
         }
 
-	const credentials = getCredentials(params)
+        const credentials = getCredentials(params)
 
         const s3instance = params.endpoint ?
             s3instanceWithEndpoint(params.endpoint, credentials) :
@@ -138,7 +138,7 @@ const upload = (job, settings, src, params, onProgress, onComplete) => {
         }
         if (params.metadata) awsParams.Metadata = params.metadata;
 
-	const credentials = getCredentials(params)
+        const credentials = getCredentials(params)
 
         const s3instance = params.endpoint ?
             s3instanceWithEndpoint(params.endpoint, credentials) :


### PR DESCRIPTION
For use-cases where you're downloading or uploading from buckets in different S3 (or other provider) accounts, it's currently difficult to rely on the current S3 provider implementation.

This update adds the option to:

- Specify an AWS credentials profile in params (see [SharedIniFileCredentials](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SharedIniFileCredentials.html)
- Specify an access key ID and secret access key in params
- Specify a profile in environment variables (AWS_PROFILE)

It resolves credentials in the following order:

- Profile specified in params, if not specified then
- Access key ID and secret access key in params, if not specified then
- Profile specified in environment variables, if not specified then
- Access key ID and secret access key in params, if not specified then
- Default credentials detected by the AWS SDK

