### PR TITLE
Just as the worker, the cli should also write the render license file.

### DIFF
--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -175,6 +175,8 @@ settings.verbose = settings.debug;
 if (settings['no-license']) {
     settings.addLicense = false;
     delete settings['no-license'];
+} else {
+    settings.addLicense = true;
 }
 
 if (args['--cleanup']) {


### PR DESCRIPTION
Especially, the file is needed for AE >= v17.5.