### PR TITLE
Append file extension based on content-type

### DIFF
--- a/packages/nexrender-core/package.json
+++ b/packages/nexrender-core/package.json
@@ -12,6 +12,7 @@
     "file-uri-to-path": "^2.0.0",
     "is-wsl": "^2.2.0",
     "match-all": "^1.2.5",
+    "mime-types": "^2.1.29",
     "mkdirp": "^1.0.4",
     "node-fetch": "^2.6.1",
     "requireg": "^0.2.1",


### PR DESCRIPTION
As the title says, if the asset file extension is not present, now it's being appended based on response header content-type for `http` and `https` protocols.