### PR TITLE
Cast value to string so .replace works

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -169,7 +169,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             if (Array.isArray(value)) {
                 value.forEach(item => cur.push(key, item.replace('${workPath}', job.workpath)));
             } else {
-                cur.push(key, value.replace('${workPath}', job.workpath))
+                cur.push(key, String(value).replace('${workPath}', job.workpath))
             }
             return cur;
         }, []


### PR DESCRIPTION
This is a simple fix for an issue I've been having for a while. It casts the variable value to a string so the .replace method works, otherwise it throws a nasty error.
I edited this file manually a couple months ago in production, and so far it has been fine, and I doubt it should break anything as the replace method only works on strings either way.