### PR TITLE
Job priority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7742,9 +7742,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {

--- a/packages/nexrender-server/README.md
+++ b/packages/nexrender-server/README.md
@@ -18,6 +18,7 @@ Can be changed by providing `NEXRENDER_ORDERING` env vartiable before launching 
 * `oldest-first` - FIFO queue, oldest jobs will be rendered first
 * `newest-first` - LIFO queue, newest jobs will be rendered first, oldest will be rendered last
 * `random` - Random access queue, jobs will be selected based on random counter
+* `priority` - Jobs are selected based on their priority field (default 0), in case of a collision it will choose the oldest one.
 
 ## Installation
 

--- a/packages/nexrender-server/src/routes/jobs-pickup.js
+++ b/packages/nexrender-server/src/routes/jobs-pickup.js
@@ -19,6 +19,17 @@ module.exports = async (req, res) => {
     }
     else if (process.env.NEXRENDER_ORDERING == 'newest-first') {
         job = queued[queued.length-1];
+    } else if (process.env.NEXRENDER_ORDERING = 'priority') {
+        // Get the job with the largest priority number
+        // This will also sort them by the date, so if 2 jobs have the same
+        // priority, it will choose the oldest one because that's the original state
+        // of the array in question
+        job = queued.sort((a, b) => {
+            // Quick sanitisation to make sure they're numbers
+            if (isNaN(a.priority)) a.priority = 0
+            if (isNaN(b.priority)) b.priority = 0
+            return b.priority - a.priority
+        })[0]
     }
     else { /* fifo (oldest-first) */
         job = queued[0];

--- a/packages/nexrender-types/job.js
+++ b/packages/nexrender-types/job.js
@@ -13,6 +13,7 @@ const create = job => Object.assign({
     type: 'default',
     state: 'created',
     output: '',
+    priority: job.priority ? job.priority : 0,
 
     template: {
         src: '',


### PR DESCRIPTION
Allows you to supply a numerical "priority" field for each job and the workers will then pick up the ones with the highest priority, and if there's a collision it will choose the oldest one automatically.