### PR TITLE
Fix for downloading static assets

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -75,10 +75,12 @@ const download = (job, settings, asset) => {
                       const contentType = res.headers.get('content-type')
                       const fileExt = mime.extension(contentType) || undefined
 
-                      asset.extension = fileExt
-                      if (asset.extension) {
-                        asset.dest += `.${fileExt}`
-                      }
+                       asset.extension = fileExt
+                        const destHasExtension = path.extname(asset.dest) ? true : false
+                        //don't do this if asset.dest already has extension else it gives you example.jpg.jpg  like file in case of  assets and aep/aepx file 
+                        if (asset.extension && !destHasExtension) {
+                            asset.dest += `.${fileExt}`
+                        }
                     }
 
                     const stream = fs.createWriteStream(asset.dest)


### PR DESCRIPTION
**Problem:**
My static assets was like 
```
{
name:"example.jpg",
type:"static",
src:"https://example.com/example.jpg"
}, 
```
 it gives download file as **example.jpg.jpg** as it appends the extension in **asset.dest**,
line 34 forces **destName=example.jpg** and then **assets.desc=workpath+"/"+example.jpg**, then after download  it satisfies line 74  as extension key is not there in static assets, 

**Solution:**

**it restricting now to do this by checking the extension presence in asset.dest so not to repeat like workpath+example.jpg (from asset.dest)+".jpg" (from content type) which gives /example.jpg.jpg**"