### PR TITLE
fix: prevent command prompts pop-ups in Windows

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -197,7 +197,7 @@ module.exports = (job, settings, options, type) => {
             if (settings.debug) {
                 settings.logger.log(`[${job.uid}] spawning ffmpeg process: ${binary} ${params.join(' ')}`);
             }
-            const instance = spawn(binary, params);
+            const instance = spawn(binary, params, {windowsHide: true});
             let totalDuration = 0
 
             instance.on('error', err => reject(new Error(`Error starting ffmpeg process: ${err}`)));

--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -123,6 +123,7 @@ module.exports = (job, settings) => {
         const output = [];
         const logPath = path.resolve(job.workpath, `../aerender-${job.uid}.log`)
         const instance = spawn(settings.binary, params, {
+            windowsHide: true
             // NOTE: disabled PATH for now, there were a few
             // issues related to plugins not working properly
             // env: { PATH: path.dirname(settings.binary) },


### PR DESCRIPTION
In some instances (like running nexrender-workers with pm2), a command prompt (`cmd.exe`) window would pop-up every time an external process was spawned (like `aerender` or `ffmpeg`).

To, workaround this problem (which can be quite annoying), I've added the `windowsHide` parameter to all the `spawn` calls. This will:

> Hide the subprocess console window that would normally be created on Windows systems

([Source](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options))

Related: Unitech/pm2#2182