### PR TITLE
update amazon-s3-uri package to 0.1.1 in s3 provider

### DIFF
--- a/packages/nexrender-provider-s3/package.json
+++ b/packages/nexrender-provider-s3/package.json
@@ -4,7 +4,7 @@
   "author": "inlife",
   "main": "src/index.js",
   "dependencies": {
-    "amazon-s3-uri": "0.0.3",
+    "amazon-s3-uri": "0.1.1",
     "aws-sdk": "^2.344.0"
   },
   "publishConfig": {


### PR DESCRIPTION
This fixes the NoSuchKey error that happens when URLs ending with a query string are parsed.