### PR TITLE
Add nexrender-action-unzip to external packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,6 +1343,7 @@ Here you can find a list of packages published by other contributors:
 * [HarryLafranc/nexrender-action-handbrake](https://github.com/HarryLafranc/nexrender-action-handbrake) - Encode a video with Handbrake on nexrender-postrender
 * [dberget/nexrender-action-cloudinary](https://github.com/dberget/nexrender-action-cloudinary) - Upload a video to Cloudinary platform
 * [dberget/nexrender-action-normalize-color](https://github.com/dberget/nexrender-action-normalize-color) - Normalize colors for each asset defined in options
+* [dylangarcia/nexrender-action-unzip](https://github.com/dylangarcia/nexrender-action-unzip) - Unzip composition source before starting to render
 * [somename/package-name](#) - a nice description of a nice package doing nice things
 
 Since nexrender allows to use external packages installed globally from npm, its quite easy to add your own modules


### PR DESCRIPTION
I've created https://github.com/dylangarcia/nexrender-action-unzip to help aid in workflows that require a full project to be downloaded and extracted before rendering.