### PR TITLE
Added nested comps to nexrender.jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,8 @@ by specifying `src`, and one of the `layerName` or `layerIndex` options.
 * `layerName`: string, target layer name in the After Effects project
 * `layerIndex`: integer, can be used instead of `layerName` to select a layer by providing an index, starting from 1 (default behavior of AE jsx scripting env)
 * `composition`: string, composition where the layer is, useful for searching layer in specific compositions. If none is provided, it uses the wildcard composition "\*",
-that will result in a wildcard composition matching, and will apply this data to every matching layer in every matching composition.
+that will result in a wildcard composition matching, and will apply this data to every matching layer in every matching composition. If you want to search in a nested composition you can provide a path to that composition using  `"->"` delimiter.  
+For example, `"FULL_HD->intro->logo comp"` matches a composition named `logo comp` that is used in composition `intro` which in turn is used in composition `FULL_HD`. Note, that `FULL_HD` doesn't have to be the root composition. Make sure to specify a **composition** name, not a layer name.
 * `name`: string, and optional filename that the asset will be saved as, if not provided the `layerName` or the basename of the file will be used
 * `extension`: string, an optional extension to be added to the filename before it is sent for rendering. This is because After Effects expects the file extension to match the content type of the file. If none is provided, the filename will be unchanged.
 * `useOriginal`: boolean, an optional feature specific to the `file://` protocol, that prevents nexrender from copying an asset to local temp folder, and use original instead
@@ -631,7 +632,8 @@ To do that a special asset of type `data` can be used.
 * `value`: mixed, optional, indicates which value you want to be set to a specified property
 * `expression`: string, optional, allows you to specify an expression that can be executed every frame to calculate the value
 * `composition`: string, composition where the layer is, useful for searching layer in specific compositions. If none is provided, it uses the wildcard composition "\*",
-that will result in a wildcard composition matching, and will apply this data to every matching layer in every matching composition.
+that will result in a wildcard composition matching, and will apply this data to every matching layer in every matching composition. If you want to search in a nested composition you can provide a path to that composition using  `"->"` delimiter.  
+For example, `"FULL_HD->intro->logo comp"` matches a composition named `logo comp` that is used in composition `intro` which in turn is used in composition `FULL_HD`. Note, that `FULL_HD` doesn't have to be the root composition. Make sure to specify a **composition** name, not a layer name.
 
 Since both `value` and `expression` are optional you can provide them in any combination, depending on the effect you want to achieve.
 Providing value will set the exact value for the property right after execution, and providing an expression will make sure it will be evaluated every frame.

--- a/packages/nexrender-core/src/assets/nexrender.jsx
+++ b/packages/nexrender-core/src/assets/nexrender.jsx
@@ -48,7 +48,7 @@ nexrender.selectCompositionsByName = function(name, callback) {
           parentChain.length > 0 &&
           comp.usedIn.length > 0
         ) {
-          parentComp = null;
+          var parentComp = null;
           for (var i = 0; i < comp.usedIn.length; i++) {
             if (
               comp.usedIn[i] instanceof CompItem &&

--- a/packages/nexrender-core/src/assets/nexrender.jsx
+++ b/packages/nexrender-core/src/assets/nexrender.jsx
@@ -34,9 +34,45 @@ nexrender.replaceFootage = function (layer, filepath) {
     return true;
 };
 
-/* envoke callback for every compostion matching specific name */
+/* invoke callback for every composition matching specific name */
 nexrender.selectCompositionsByName = function(name, callback) {
     var items = [];
+    var nameChain = name.split("->");
+    var name = nameChain.pop();
+
+    function isNestedComp(comp, name, parentChain) {
+        if (
+          name &&
+          comp.name === name &&
+          parentChain &&
+          parentChain.length > 0 &&
+          comp.usedIn.length > 0
+        ) {
+          parentComp = null;
+          for (var i = 0; i < comp.usedIn.length; i++) {
+            if (
+              comp.usedIn[i] instanceof CompItem &&
+              comp.usedIn[i].name === parentChain[parentChain.length - 1]
+            ) {
+              parentComp = comp.usedIn[i];
+              break;
+            }
+          }
+
+          if (parentComp) {
+            if (parentChain.length === 1) {
+              return true;
+            } else {
+              return isNestedComp(
+                parentComp,
+                parentChain.pop(),
+                parentChain
+              );
+            }
+          }
+        }
+        return false;
+    }
 
     /* step 1: collect all matching compositions */
     var len = app.project.items.length;
@@ -46,12 +82,16 @@ nexrender.selectCompositionsByName = function(name, callback) {
 
         if (name !== "*" && item.name !== name) {
             continue;
-        } else {
+        } else if (nameChain.length === 0) { // if the comp name wasn't hierarchical
             items.push(item);
+        } else if (isNestedComp(item, name, nameChain)) { // otherwise only add the comp if it matches the hierarchical position defined in the comp name
+            items.push(item);
+        } else {
+            continue;
         }
     }
 
-    /* step 2: envoke callback for every match */
+    /* step 2: invoke callback for every match */
     var len = items.length;
     for (var i = 0; i < len; i++) {
         callback(items[i]);
@@ -83,7 +123,7 @@ nexrender.selectLayersByName = function(compositionName, name, callback, types) 
             }
         }
 
-        /* step 2: envoke callback for every match */
+        /* step 2: invoke callback for every match */
         var len = items.length;
         for (var i = 0; i < len; i++) {
             callback(items[i], name);
@@ -122,7 +162,7 @@ nexrender.selectLayersByType = function(
       }
     }
 
-    /* step 2: envoke callback for every match */
+    /* step 2: invoke callback for every match */
     var len = items.length;
     for (var i = 0; i < len; i++) {
       callback(items[i]);


### PR DESCRIPTION
I made a few small changes to `selectCompositionsByName()` function in `nexrender.jsx` that enables searching nested compositions. Nested compositions must be specified in a job json like this: `"Parent Comp->Child Comp->Grandchild Comp"`. 

For example
```json
{
  "type": "data",
  "composition": "FULL_HD->intro->logo comp",
  "layerName": "logo",
  "property": "Transform.Position",
  "value": [100, 150]
}
```
Note, that you have to specify the child composition name, not a layer name.

The regular composition names, as well as `*` still work. 