### PR TITLE
Added external link to nexrender-action-template-unzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1360,6 +1360,7 @@ Here you can find a list of packages published by other contributors:
 * [dberget/nexrender-action-cloudinary](https://github.com/dberget/nexrender-action-cloudinary) - Upload a video to Cloudinary platform
 * [dberget/nexrender-action-normalize-color](https://github.com/dberget/nexrender-action-normalize-color) - Normalize colors for each asset defined in options
 * [dylangarcia/nexrender-action-unzip](https://github.com/dylangarcia/nexrender-action-unzip) - Unzip composition source before starting to render
+* [pilskalns/nexrender-action-template-unzip](https://github.com/Pilskalns/nexrender-action-template-unzip) - Unzip template and find (first) `.aep` file within it. Minimal config.
 * [somename/package-name](#) - a nice description of a nice package doing nice things
 
 Since nexrender allows to use external packages installed globally from npm, its quite easy to add your own modules


### PR DESCRIPTION
I see there is already another package on the same topic, but this has a different approach that tackles following issues:

1st: the structure of files within the ZIP might differ from one to another - a user could zip files in the root or a directory within the zip or whatever (users can be messy)
2nd: the name of `.aep` file is not known and in fact, is not important - the ZIP templates are being worked by the `.zip` basename.