### PR TITLE
Add additional AE 2022 autofind string match for Mac

### DIFF
--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -12,6 +12,7 @@ const defaultPaths = {
         '/Applications/Adobe After Effects CC 2019',
         '/Applications/Adobe After Effects 2020',
         '/Applications/Adobe After Effects 2021',
+        '/Applications/Adobe After Effects 2022',
         '/Applications/Adobe After Effects CC 2021',
         '/Applications/Adobe After Effects CC 2022',
     ],


### PR DESCRIPTION
#651 was good but didn't quite cover all the possibilities for the Adobe After Effects 2022 path on Mac. This adds in an additional matching string for completeness.