### PR TITLE
Enable action functions to be passed directly in actions key in settings

### DIFF
--- a/packages/nexrender-core/readme.md
+++ b/packages/nexrender-core/readme.md
@@ -66,3 +66,4 @@ Second one is responsible for mainly job-related operations of the full cycle: d
 * `addLicense` - boolean, providing false will disable ae_render_only_node.txt license file auto-creation (true by default)
 * `forceCommandLinePatch` - boolean, providing true will force patch re-installation
 * `onInstanceSpawn` - a callback, if provided, gets called when **aerender** instance is getting spawned, with instance pointer. Can be later used to kill a hung aerender process. Callback signature: `function (instance, job, settings) {}`
+* `actions` - an object with keys corresponding to the `module` field when defining an action, value should be a function matching expected signature of an action. Used for defining actions programmatically without needing to package the action as a separate package

--- a/packages/nexrender-core/readme.md
+++ b/packages/nexrender-core/readme.md
@@ -36,6 +36,11 @@ const main = async () => {
         skipCleanup: true,
         addLicense: false,
         debug: true,
+        actions: {
+            "custom-action": (job, settings, {input, params}, type) => {
+                // Custom action code
+            }
+        },
     })
 }
 

--- a/packages/nexrender-core/src/tasks/actions.js
+++ b/packages/nexrender-core/src/tasks/actions.js
@@ -21,10 +21,14 @@ module.exports = actionType => (job, settings) => {
     settings.logger.log(`[${job.uid}] applying ${actionType} actions...`);
 
     return PromiseSerial((job.actions[actionType] || []).map(action => () => {
-        return requireg(action.module)(job, settings, action, actionType).catch(err => {
-            return Promise.reject(new Error(`Error loading ${actionType} module ${action.module}: ${err}`))
-        });
+        if(settings.actions[action.module]){
+            return settings.actions[action.module](job, settings, action, actionType);
+        }else{
+            return requireg(action.module)(job, settings, action, actionType);
+        }
     })).then(() => {
         return Promise.resolve(job)
+    }).catch(err => {
+        return Promise.reject(new Error(`Error loading ${actionType} module ${action.module}: ${err}`));
     });
 }

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -77,5 +77,6 @@ Available settings (almost same as for `nexrender-core`):
 * `stopOnError` - boolean, stop the pick-up-and-render process if an error occurs (false by default)
 * `polling` - number, amount of miliseconds to wait before checking queued projects from the api, if specified will be used instead of NEXRENDER_API_POLLING env variable
 * `wslMap` - string, drive letter of your WSL mapping in Windows
-* `aeParams` - array of strings, any additional params that will be passed to the aerender binary, a name-value parameter pair separated by a space
+* `aeParams` - array of strings, any additional params that will be passed to the aerender binary, a name-value parameter pair separated by a space,
+* `actions` - an object with keys corresponding to the `module` field when defining an action, value should be a function matching expected signature of an action. Used for defining actions programmatically without needing to package the action as a separate package
 

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -52,6 +52,11 @@ const main = async () => {
         skipCleanup: true,
         addLicense: false,
         debug: true,
+        actions: {
+            "custom-action": (job, settings, {input, params}, type) => {
+                // Custom action code
+            }
+        },
     })
 }
 


### PR DESCRIPTION
Resolves #671

Also updated the readme files to include the new `actions` field. Implementation should be fully backwards compatible. 

If an action is both defined in the `actions` object and installed as a package (or there is a name collision) the function in the `actions` object takes precedence.