### PR TITLE
Add mutex lock to server pickup route

### DIFF
--- a/packages/nexrender-server/package-lock.json
+++ b/packages/nexrender-server/package-lock.json
@@ -25,6 +25,14 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -222,6 +230,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/packages/nexrender-server/package.json
+++ b/packages/nexrender-server/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@nexrender/types": "^1.27.0",
     "arg": "^4.1.0",
+    "async-mutex": "^0.3.2",
     "chalk": "^2.4.2",
     "micro": "^9.3.3",
     "micro-cors": "^0.1.1",

--- a/packages/nexrender-server/src/routes/jobs-pickup.js
+++ b/packages/nexrender-server/src/routes/jobs-pickup.js
@@ -1,40 +1,49 @@
 const { send }   = require('micro')
 const { fetch }  = require('../helpers/database')
 const { update } = require('../helpers/database')
+const { Mutex }  = require('async-mutex');
+
+const mutex = new Mutex();
 
 module.exports = async (req, res) => {
-    console.log(`fetching a pickup job for a worker`)
+    const release = await mutex.acquire();
 
-    const listing = await fetch()
-    const queued  = listing.filter(job => job.state == 'queued')
+    try{
+        console.log(`fetching a pickup job for a worker`)
 
-    if (queued.length < 1) {
-        return send(res, 200, {})
+        const listing = await fetch()
+        const queued  = listing.filter(job => job.state == 'queued')
+
+        if (queued.length < 1) {
+            return send(res, 200, {})
+        }
+
+        let job;
+
+        if (process.env.NEXRENDER_ORDERING == 'random') {
+            job = queued[Math.floor(Math.random() * queued.length)];
+        }
+        else if (process.env.NEXRENDER_ORDERING == 'newest-first') {
+            job = queued[queued.length-1];
+        } else if (process.env.NEXRENDER_ORDERING = 'priority') {
+            // Get the job with the largest priority number
+            // This will also sort them by the date, so if 2 jobs have the same
+            // priority, it will choose the oldest one because that's the original state
+            // of the array in question
+            job = queued.sort((a, b) => {
+                // Quick sanitisation to make sure they're numbers
+                if (isNaN(a.priority)) a.priority = 0
+                if (isNaN(b.priority)) b.priority = 0
+                return b.priority - a.priority
+            })[0]
+        }
+        else { /* fifo (oldest-first) */
+            job = queued[0];
+        }
+
+        /* update the job locally, and send it to the worker */
+        send(res, 200, await update(job.uid, { state: 'picked', executor: req.socket.remoteAddress }))
+    } finally {
+        release();
     }
-
-    let job;
-
-    if (process.env.NEXRENDER_ORDERING == 'random') {
-        job = queued[Math.floor(Math.random() * queued.length)];
-    }
-    else if (process.env.NEXRENDER_ORDERING == 'newest-first') {
-        job = queued[queued.length-1];
-    } else if (process.env.NEXRENDER_ORDERING = 'priority') {
-        // Get the job with the largest priority number
-        // This will also sort them by the date, so if 2 jobs have the same
-        // priority, it will choose the oldest one because that's the original state
-        // of the array in question
-        job = queued.sort((a, b) => {
-            // Quick sanitisation to make sure they're numbers
-            if (isNaN(a.priority)) a.priority = 0
-            if (isNaN(b.priority)) b.priority = 0
-            return b.priority - a.priority
-        })[0]
-    }
-    else { /* fifo (oldest-first) */
-        job = queued[0];
-    }
-
-    /* update the job locally, and send it to the worker */
-    send(res, 200, await update(job.uid, { state: 'picked', executor: req.socket.remoteAddress }))
 }


### PR DESCRIPTION
Resolves #670

Ensures that the jobs picked up by the workers will always be unique.

I didn't add a timeout to the mutex lock as I think the way it's currently used shouldn't cause a stale mutex to ever occur but including it isn't too difficult either, just figuring out the right amount of time for the timeout is a bit tricky. I would recommend leaving this as is for now and I'm happy to add the timeout if it turns out stale mutex is a possibility in this case.