### PR TITLE
Fix ffmpeg Error: EBUSY (action-encode module)

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -48,7 +48,7 @@ const getBinary = (job, settings) => {
 
                 stream
                     .on('error', errorHandler)
-                    .on('finish', () => {
+                    .on('close', () => {
                         settings.logger.log(`> ffmpeg binary ${version} was successfully downloaded`)
                         fs.chmodSync(output, 0o755)
                         resolve(output)


### PR DESCRIPTION
This issue was already fixed in #331 , but there has been a regression.

The result of downloading the ffmpeg binary should only be resolved when the writestream is closed, not when it is finished.