### PR TITLE
fix @nexrender/action-upload dependency of @nexredner/provider-sftp

### DIFF
--- a/packages/nexrender-action-upload/package.json
+++ b/packages/nexrender-action-upload/package.json
@@ -16,6 +16,6 @@
     "@nexrender/provider-ftp": "^1.17.2",
     "@nexrender/provider-gs": "^1.21.3",
     "@nexrender/provider-s3": "^1.21.4",
-    "@nexrender/provider-sftp": "^1.37.10"
+    "@nexrender/provider-sftp": "^1.37.9"
   }
 }


### PR DESCRIPTION
this is #707 bug patch

@nexrender/action-copy depends on @nexrender/provider-sftp@^1.37.10 which is not exists