### PR TITLE
fix the dates when inserting to redis

### DIFF
--- a/packages/nexrender-database-redis/src/index.js
+++ b/packages/nexrender-database-redis/src/index.js
@@ -36,6 +36,11 @@ const scan = async parser => {
 
 /* public api */
 const insert = async entry => {
+    const now = new Date();
+
+    entry.updatedAt = now;
+    entry.createdAt = now;
+    
     await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry));
 };
 


### PR DESCRIPTION
When inserting a new job and using the `nexrender-database-redis`, the created and updated date are not set.. This is not in line with the [disk.js](https://github.com/inlife/nexrender/blob/master/packages/nexrender-server/src/helpers/disk.js#L38-L46). I aligned the behavior to be the same.