### PR TITLE
fix scan not to return null elements back

### DIFF
--- a/packages/nexrender-database-redis/src/index.js
+++ b/packages/nexrender-database-redis/src/index.js
@@ -22,7 +22,7 @@ const scan = async parser => {
         results = results.concat(keys);
 
         if (cursor === '0') {
-            results = await results.map(parser);
+            results = await results.map(parser).filter(e => e !== null && e !== undefined);
             return results;
         } else {
             return _scan(parser);


### PR DESCRIPTION
The `scan` function in the `nexrender-database-redis` is accepting a parser that can transform a redis key to a object.. However, in the `fetch`, the mapper actually loads the whole object from the redis and returns it.. There is a possibility for a race condition here, that a key that has been found by scan, is deleted before the mapper manage to fetch it from the redis.. In that case mapper will return `null` object.. 

Once the array with a null get's to the `nexrender-server`, there will be an exception as the server expects that `fetch` returns non-null jobs of course.. This results in `HTTP 500`.

We tested the fix and here's the result (left half before the fix, right half after):

![image](https://user-images.githubusercontent.com/10600041/156880536-c06caec9-a0fa-4b67-9586-a981179c504c.png)
