### PR TITLE
Update cleanup.js

### DIFF
--- a/packages/nexrender-core/src/tasks/cleanup.js
+++ b/packages/nexrender-core/src/tasks/cleanup.js
@@ -23,6 +23,7 @@ module.exports = function(job, settings) {
             } else {
                 settings.logger.log(`[${job.uid}] Temporary AfterEffects could not be deleted. (Error: ${err.code}). Please delete the folder manually: ${job.workpath}`)
             }
+
             resolve(job)
         })
     })

--- a/packages/nexrender-core/src/tasks/cleanup.js
+++ b/packages/nexrender-core/src/tasks/cleanup.js
@@ -11,16 +11,15 @@ module.exports = function(job, settings) {
 
     return new Promise((resolve) => {
         settings.logger.log(`[${job.uid}] cleaning up...`);
-
-        rimraf(job.workpath, {glob: false}, (err) => {
+        if(!job.workpath){ job.workpath = settings.workpath.concat("/", job.uid, "/")}//Sometimes this attribute (workpath) was undefined.
+       	rimraf(job.workpath, {glob: false}, (err) => {
             if (!err) {
                 settings.logger.log(`[${job.uid}] Temporary AfterEffects project deleted. If you want to inspect it for debugging, use "--skip-cleanup"`)
             } else {
                 settings.logger.log(`[${job.uid}] Temporary AfterEffects could not be deleted. (Error: ${err.code}). Please delete the folder manually: ${job.workpath}`)
             }
-
             resolve(job)
-        })
+        })    
     })
 };
 

--- a/packages/nexrender-core/src/tasks/cleanup.js
+++ b/packages/nexrender-core/src/tasks/cleanup.js
@@ -11,15 +11,20 @@ module.exports = function(job, settings) {
 
     return new Promise((resolve) => {
         settings.logger.log(`[${job.uid}] cleaning up...`);
-        if(!job.workpath){ job.workpath = settings.workpath.concat("/", job.uid, "/")}//Sometimes this attribute (workpath) was undefined.
-       	rimraf(job.workpath, {glob: false}, (err) => {
+        
+        // sometimes this attribute (workpath) is undefined
+        if (!job.workpath) {
+            job.workpath = settings.workpath.concat('/', job.uid, '/')
+        }
+       	
+        rimraf(job.workpath, {glob: false}, (err) => {
             if (!err) {
                 settings.logger.log(`[${job.uid}] Temporary AfterEffects project deleted. If you want to inspect it for debugging, use "--skip-cleanup"`)
             } else {
                 settings.logger.log(`[${job.uid}] Temporary AfterEffects could not be deleted. (Error: ${err.code}). Please delete the folder manually: ${job.workpath}`)
             }
             resolve(job)
-        })    
+        })
     })
 };
 


### PR DESCRIPTION
Rebuilding workpath. Sometimes it's undefined and we need to have this path in order to clean up.