### PR TITLE
set stop-on-error to false

### DIFF
--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -161,6 +161,10 @@ console.log(chalk`> starting {bold.cyan nexrender-worker} endpoint {bold ${serve
 
 let settings = {};
 const opt = (key, arg) => {if (args[arg]) {
+    //If not specified == true, otherwise false
+    if(key === "stopOnError"){
+        args[arg] = false;
+    }
     settings[key] = args[arg];
 }}
 


### PR DESCRIPTION
It's impossible to disable "stop-on-error" since it was typed Boolean.
This condition allows it to be set to false if it's filled in with the worker.