### PR TITLE
Allow download from digitaloceanspaces in provider s3

### DIFF
--- a/packages/nexrender-provider-s3/src/index.js
+++ b/packages/nexrender-provider-s3/src/index.js
@@ -1,5 +1,5 @@
 const fs  = require('fs')
-const uri = require('amazon-s3-uri')
+const uri = require('./uri')
 const AWS = require('aws-sdk/global')
 const S3 = require('aws-sdk/clients/s3')
 
@@ -56,10 +56,6 @@ const s3instanceWithEndpoint = (endpoint, credentials) => {
 /* define public methods */
 const download = (job, settings, src, dest, params, /* type */) => {
     src = src.replace('s3://', 'http://')
-
-    if (src.indexOf('digitaloceanspaces.com') !== -1) {
-        throw new Error('nexrender: Digital Ocean Spaces is not yet supported by the package: amazon-s3-uri')
-    }
 
     const parsed = uri(src)
     const file = fs.createWriteStream(dest)

--- a/packages/nexrender-provider-s3/src/uri.js
+++ b/packages/nexrender-provider-s3/src/uri.js
@@ -1,0 +1,49 @@
+const uriS3 = require('amazon-s3-uri')
+const url = require('url')
+
+function uriDigitalOcean(src) {
+  const parsed = url.parse(src)
+  const result = parsed.host.match(/(([^.]+)\.)?([^.]+)\.digitaloceanspaces\.com/)
+
+  if (!result) {
+    return {
+        uri: parsed,
+        region: null,
+        bucket: null,
+        key: null,
+        isPathStyle: false
+    }
+  }
+
+  const region = result[3]
+  let bucket = result[2]
+  let key
+  let isPathStyle = false
+
+  const pieces = parsed.pathname.split('/')
+  if (!bucket) {
+    bucket = pieces.slice(1, 2).join('/')
+    key = pieces.slice(2, pieces.length).join('/')
+    isPathStyle = true
+  } else {
+    key = pieces.slice(1, pieces.length).join('/')
+    isPathStyle = false
+  }
+
+  return {
+      uri: parsed,
+      region,
+      bucket,
+      key,
+      isPathStyle,
+  }
+}
+
+function uri(src) {
+    if (src.indexOf('digitaloceanspaces.com') !== -1) {
+      return uriDigitalOcean(src)
+    }
+    return uriS3(src)
+}
+
+module.exports = uri


### PR DESCRIPTION
Implemented a light `amazon-s3-uri` version to allow file downloads from  digitaloceanspaces, used only when needed.