### PR TITLE
Deprecate getJob() and implement fetchJob()

### DIFF
--- a/packages/nexrender-api/src/job.js
+++ b/packages/nexrender-api/src/job.js
@@ -50,12 +50,6 @@ module.exports = (fetch, polling) => ({
             body: JSON.stringify(data),
         }), polling),
     
-    getJob: async id =>
-        withEventEmitter(fetch, await fetch(`/jobs/${id}`, {
-            method: 'get',
-            headers: { 'content-type': 'application/json' },
-        }), polling),
-    
     resumeJob: async id =>
         withEventEmitter(fetch, await fetch(`/jobs/${id}`), polling),
 
@@ -74,4 +68,11 @@ module.exports = (fetch, polling) => ({
 
 /* deprecated method name */
 /* keeping for now for, backward compatibility */
-module.exports.removejob = module.exports.removeJob
+module.exports.removejob = async id => {
+    console.warn("`removejob()` has been deprecated and will be removed in a future version. Please use `removeJob()` instead.")
+    return module.exports.removeJob(id)
+}
+module.exports.getJob = async id => {
+    console.warn("`getJob()` has been deprecated and will be removed in a future version. Please use `resumeJob()` instead.")
+    return module.exports.resumeJob(id)
+}

--- a/packages/nexrender-api/src/job.js
+++ b/packages/nexrender-api/src/job.js
@@ -41,6 +41,7 @@ const withEventEmitter = (fetch, job, polling = NEXRENDER_JOB_POLLING) => {
 
 module.exports = (fetch, polling) => ({
     listJobs: async () => await fetch(`/jobs`),
+    fetchJob: async id => await fetch(`/jobs/${id}`),
     pickupJob: async () => await fetch(`/jobs/pickup`),
 
     addJob: async data =>


### PR DESCRIPTION
Resolves #752 

In addition to deprecating `getJob()`, using deprecated functions such as `getJob()` or `removejob()` will not print a deprecation warning message.

Also implemented `fetchJob()` (which I wanted to name `getJob()` originally) that similar to `listJob()` but only return one job object and not in an array.