### PR TITLE
adding support for finding aerender.exe in adobe after effects 2023

### DIFF
--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -15,6 +15,7 @@ const defaultPaths = {
         '/Applications/Adobe After Effects 2022',
         '/Applications/Adobe After Effects CC 2021',
         '/Applications/Adobe After Effects CC 2022',
+        '/Applications/Adobe After Effects CC 2023',
     ],
     win32: [
         'C:\\Program Files\\Adobe\\After Effects CC',

--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -28,6 +28,7 @@ const defaultPaths = {
         'C:\\Program Files\\Adobe\\After Effects 2020\\Support Files',
         'C:\\Program Files\\Adobe\\After Effects 2021\\Support Files',
         'C:\\Program Files\\Adobe\\After Effects 2022\\Support Files',
+        'C:\\Program Files\\Adobe\\After Effects 2023\\Support Files',
 
         'C:\\Program Files\\Adobe\\Adobe After Effects CC',
         'C:\\Program Files\\Adobe\\Adobe After Effects CC\\Support Files',
@@ -40,6 +41,7 @@ const defaultPaths = {
         'C:\\Program Files\\Adobe\\Adobe After Effects 2020\\Support Files',
         'C:\\Program Files\\Adobe\\Adobe After Effects 2021\\Support Files',
         'C:\\Program Files\\Adobe\\Adobe After Effects 2022\\Support Files',
+        'C:\\Program Files\\Adobe\\Adobe After Effects 2023\\Support Files',
     ],
     wsl: [
         '/mnt/c/Program Files/Adobe/After Effects CC',
@@ -53,6 +55,7 @@ const defaultPaths = {
         '/mnt/c/Program Files/Adobe/After Effects 2020/Support Files',
         '/mnt/c/Program Files/Adobe/After Effects 2021/Support Files',
         '/mnt/c/Program Files/Adobe/After Effects 2022/Support Files',
+        '/mnt/c/Program Files/Adobe/After Effects 2023/Support Files',
 
         '/mnt/c/Program Files/Adobe/Adobe After Effects CC',
         '/mnt/c/Program Files/Adobe/Adobe After Effects CC/Support Files',
@@ -65,6 +68,7 @@ const defaultPaths = {
         '/mnt/c/Program Files/Adobe/Adobe After Effects 2020/Support Files',
         '/mnt/c/Program Files/Adobe/Adobe After Effects 2021/Support Files',
         '/mnt/c/Program Files/Adobe/Adobe After Effects 2022/Support Files',
+        '/mnt/c/Program Files/Adobe/Adobe After Effects 2023/Support Files',
     ],
 }
 


### PR DESCRIPTION
Hi, we're using nexrender with a fresh new installation of AE and the executable was not found, as the new installation path `C:\\Program Files\\Adobe\\Adobe After Effects 2023\\Support Files` is not managed by the autofind helper.

The PR extends defaults paths to handle new "2023" paths.