### PR TITLE
Use path join in task cleanup

### DIFF
--- a/packages/nexrender-core/src/tasks/cleanup.js
+++ b/packages/nexrender-core/src/tasks/cleanup.js
@@ -1,4 +1,5 @@
 const rimraf = require('rimraf')
+const path = require('path')
 
 /**
  * Clean up all workpath files and remove folder
@@ -11,12 +12,12 @@ module.exports = function(job, settings) {
 
     return new Promise((resolve) => {
         settings.logger.log(`[${job.uid}] cleaning up...`);
-        
+
         // sometimes this attribute (workpath) is undefined
         if (!job.workpath) {
-            job.workpath = settings.workpath.concat('/', job.uid, '/')
+            job.workpath = path.join(settings.workpath, job.uid)
         }
-       	
+
         rimraf(job.workpath, {glob: false}, (err) => {
             if (!err) {
                 settings.logger.log(`[${job.uid}] Temporary AfterEffects project deleted. If you want to inspect it for debugging, use "--skip-cleanup"`)


### PR DESCRIPTION
In task cleanup use`path.join` to make it works also on windows.