### PR TITLE
Task render looking for also mp4 files for AE 2023

### DIFF
--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -190,6 +190,13 @@ module.exports = (job, settings) => {
             const existsMovOutputFile = fs.existsSync(movOutputFile)
             if (existsMovOutputFile) {
               job.output = movOutputFile
+            } else {
+                // AE 2023 use mp4 output files
+                const mp4OutputFile = outputFile.replace(/\.avi$/g, '.mp4')
+                const existsMp4OutputFile = fs.existsSync(mp4OutputFile)
+                if (existsMp4OutputFile) {
+                    job.output = mp4OutputFile
+                }
             }
 
             if (!fs.existsSync(job.output)) {


### PR DESCRIPTION
AE2023 seems to use `.mp4` as default file format for result.