### PR TITLE
Feature: tag selector, worker to pickup job wiith specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Job structure has more fields, that we haven't checked out yet. The detailed ver
 
 ```js
 {
+    "tags": String,
+    "priority": Number,
     "template": {
         "src": String,
         "composition": String,
@@ -374,6 +376,10 @@ Job structure has more fields, that we haven't checked out yet. The detailed ver
 
 Majority of the fields are just proxied to the `aerender` binary, and their descriptions and default
 values can be checked [here](https://helpx.adobe.com/after-effects/using/automated-rendering-network-rendering.html).
+
+- `tags` (optional) (example `primary,plugins` : comma delimited ) is a piece of information that describes the job that it is assigned to. It can be used by the worker(s) / or api client(s) to pickup the job with specific tags (see `tagSelector` [here](packages/nexrender-worker) ). 
+
+- `priority` (default 0) is a number of priority. Jobs are selected based on their priority field by the worker, in case of a collision it will choose the oldest one.
 
 - `onChange` is a [callback](https://github.com/inlife/nexrender/blob/master/packages/nexrender-core/src/helpers/state.js) which will be triggered every time the job state is changed (happens on every task change).
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Job structure has more fields, that we haven't checked out yet. The detailed ver
 Majority of the fields are just proxied to the `aerender` binary, and their descriptions and default
 values can be checked [here](https://helpx.adobe.com/after-effects/using/automated-rendering-network-rendering.html).
 
-- `tags` (optional) (example `primary,plugins` : comma delimited ) is a piece of information that describes the job that it is assigned to. It can be used by the worker(s) / or api client(s) to pickup the job with specific tags (see `tagSelector` [here](packages/nexrender-worker) ). 
+- `tags` (optional) (example `primary,plugins` : comma delimited ) is a piece of information that describes the job that it is assigned to. It can be used by the worker(s) / or api client(s) to pickup the job with specific tags (see `tagSelector` [here](packages/nexrender-worker) ). Tags name must be an alphanumeric.
 
 - `priority` (default 0) is a number of priority. Jobs are selected based on their priority field by the worker, in case of a collision it will choose the oldest one.
 

--- a/packages/nexrender-api/src/job.js
+++ b/packages/nexrender-api/src/job.js
@@ -42,7 +42,7 @@ const withEventEmitter = (fetch, job, polling = NEXRENDER_JOB_POLLING) => {
 module.exports = (fetch, polling) => ({
     listJobs: async () => await fetch(`/jobs`),
     fetchJob: async id => await fetch(`/jobs/${id}`),
-    pickupJob: async () => await fetch(`/jobs/pickup`),
+    pickupJob: async (selector) => await fetch(`/jobs/pickup${ selector ? `/${selector}` : '' }`),
 
     addJob: async data =>
         withEventEmitter(fetch, await fetch(`/jobs`, {

--- a/packages/nexrender-server/README.md
+++ b/packages/nexrender-server/README.md
@@ -98,7 +98,12 @@ Removes provided job from the server.
 
 ### GET `/api/v1/jobs/pickup`
 
-An internall method, used by worker to fetch a random job from the list, and start rendering.
+An internal method, used by worker to fetch a random job from the list, and start rendering.
+Probably should not be used by users, unless they know what are they doing.
+
+### GET `/api/v1/jobs/pickup/:tags`
+
+An internal method, used by worker to fetch a random job with specific tags from the list, and start rendering.
 Probably should not be used by users, unless they know what are they doing.
 
 ### GET `/api/v1/health`

--- a/packages/nexrender-server/README.md
+++ b/packages/nexrender-server/README.md
@@ -103,7 +103,7 @@ Probably should not be used by users, unless they know what are they doing.
 
 ### GET `/api/v1/jobs/pickup/:tags`
 
-An internal method, used by worker to fetch a random job with specific tags from the list, and start rendering.
+An internal method, used by worker to fetch a random job with specific tags from the list, and start rendering. Tags name must be an alphanumeric.
 Probably should not be used by users, unless they know what are they doing.
 
 ### GET `/api/v1/health`

--- a/packages/nexrender-server/src/helpers/functions.js
+++ b/packages/nexrender-server/src/helpers/functions.js
@@ -1,0 +1,5 @@
+const arrayIntersec = (array1,array2)=>array1.filter(n => array2.indexOf(n) !== -1)
+
+module.exports = {
+    arrayIntersec
+}

--- a/packages/nexrender-server/src/index.js
+++ b/packages/nexrender-server/src/index.js
@@ -15,6 +15,7 @@ const subhandler = router(
     ns(get('/jobs',             require('./routes/jobs-fetch'))),
     ns(get('/jobs/status',      require('./routes/jobs-status'))),
     ns(get('/jobs/pickup',      require('./routes/jobs-pickup'))),
+    ns(get('/jobs/pickup/:tags',require('./routes/jobs-pickup'))),
     ns(get('/jobs/:uid/status', require('./routes/jobs-status'))),
     ns(get('/jobs/:uid',        require('./routes/jobs-fetch'))),
     ns(put('/jobs/:uid',        require('./routes/jobs-update'))),

--- a/packages/nexrender-server/src/routes/jobs-create.js
+++ b/packages/nexrender-server/src/routes/jobs-create.js
@@ -5,6 +5,11 @@ const { insert }           = require('../helpers/database')
 
 module.exports = async (req, res) => {
     const data = await json(req, {limit: "100mb"})
+
+    if( typeof data.tags == 'string' ){
+        data.tags = data.tags.replace(/[^a-z0-9, ]/gi, '')
+    }
+
     const job  = await create(data); {
         job.state = 'queued';
         job.creator = req.headers["x-forwarded-for"] || req.socket.remoteAddress

--- a/packages/nexrender-server/src/routes/jobs-pickup.js
+++ b/packages/nexrender-server/src/routes/jobs-pickup.js
@@ -1,6 +1,7 @@
 const { send }   = require('micro')
 const { fetch }  = require('../helpers/database')
 const { update } = require('../helpers/database')
+const { arrayIntersec } = require('../helpers/functions')
 const { Mutex }  = require('async-mutex');
 
 const mutex = new Mutex();
@@ -12,7 +13,13 @@ module.exports = async (req, res) => {
         console.log(`fetching a pickup job for a worker`)
 
         const listing = await fetch()
-        const queued  = listing.filter(job => job.state == 'queued')
+        let queued = []
+
+        if(req.params.tags){
+            queued  = listing.filter(job => job.state == 'queued' && job.tags && arrayIntersec(req.params.tags.split(','),job.tags.split(',')).length )
+        }else{
+            queued  = listing.filter(job => job.state == 'queued')
+        }
 
         if (queued.length < 1) {
             return send(res, 200, {})

--- a/packages/nexrender-types/job.js
+++ b/packages/nexrender-types/job.js
@@ -13,6 +13,7 @@ const create = job => Object.assign({
     type: 'default',
     state: 'created',
     output: '',
+    tags: '',
     priority: job.priority ? job.priority : 0,
 
     template: {
@@ -99,6 +100,7 @@ const getRenderingStatus = job => ({
     uid: job.uid,
     state: job.state,
     type: job.type,
+    tags: job.tags || null,
     renderProgress: job.renderProgress || 0,
     error: job.error || null,
     createdAt: job.createdAt || null,

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -82,7 +82,7 @@ Available settings (almost same as for `nexrender-core`):
 * `forceCommandLinePatch` - boolean, providing true will force patch re-installation
 * `stopOnError` - boolean, stop the pick-up-and-render process if an error occurs (false by default)
 * `polling` - number, amount of miliseconds to wait before checking queued projects from the api, if specified will be used instead of NEXRENDER_API_POLLING env variable
-* `tagSelector` - string, (optional) provide the string tags (Example `primary,plugins,halowell` : comma delimited) to pickup the job with specific tags. Leave it false to ignore and pick a random job from the server with no specific tags.
+* `tagSelector` - string, (optional) provide the string tags (example `primary,plugins,halowell` : comma delimited) to pickup the job with specific tags. Leave it false to ignore and pick a random job from the server with no specific tags. Tags name must be an alphanumeric.
 * `wslMap` - string, drive letter of your WSL mapping in Windows
 * `aeParams` - array of strings, any additional params that will be passed to the aerender binary, a name-value parameter pair separated by a space,
 * `actions` - an object with keys corresponding to the `module` field when defining an action, value should be a function matching expected signature of an action. Used for defining actions programmatically without needing to package the action as a separate package

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -50,6 +50,7 @@ const main = async () => {
         workpath: '/Users/myname/.nexrender/',
         binary: '/Users/mynames/Applications/aerender',
         skipCleanup: true,
+        tagSelector: false,
         addLicense: false,
         debug: true,
         actions: {
@@ -81,6 +82,7 @@ Available settings (almost same as for `nexrender-core`):
 * `forceCommandLinePatch` - boolean, providing true will force patch re-installation
 * `stopOnError` - boolean, stop the pick-up-and-render process if an error occurs (false by default)
 * `polling` - number, amount of miliseconds to wait before checking queued projects from the api, if specified will be used instead of NEXRENDER_API_POLLING env variable
+* `tagSelector` - string, (optional) provide the string tags (Example `primary,plugins,halowell` : comma delimited) to pickup the job with specific tags. Leave it false to ignore and pick a random job from the server with no specific tags.
 * `wslMap` - string, drive letter of your WSL mapping in Windows
 * `aeParams` - array of strings, any additional params that will be passed to the aerender binary, a name-value parameter pair separated by a space,
 * `actions` - an object with keys corresponding to the `module` field when defining an action, value should be a function matching expected signature of an action. Used for defining actions programmatically without needing to package the action as a separate package

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -9,36 +9,38 @@ const rimraf    = require('rimraf')
 
 const args = arg({
     // Types
-    '--help':       Boolean,
-    '--version':    Boolean,
-    '--cleanup':    Boolean,
+    '--help':                   Boolean,
+    '--version':                Boolean,
+    '--cleanup':                Boolean,
 
-    '--host':       String,
-    '--secret':     String,
+    '--host':                   String,
+    '--secret':                 String,
 
-    '--binary':     String,
-    '--workpath':   String,
-    '--wsl-map':    String,
+    '--binary':                 String,
+    '--workpath':               String,
+    '--wsl-map':                String,
+    '--tag-selector':           String,
 
-    '--stop-on-error':  Boolean,
+    '--stop-on-error':          Boolean,
 
-    '--skip-cleanup':   Boolean,
-    '--skip-render':    Boolean,
-    '--no-license':     Boolean,
-    '--force-patch':    Boolean,
-    '--debug':          Boolean,
-    '--multi-frames':   Boolean,
-    '--multi-frames-cpu': Number,
-    '--reuse':          Boolean,
+    '--skip-cleanup':           Boolean,
+    '--skip-render':            Boolean,
+    '--no-license':             Boolean,
+    '--force-patch':            Boolean,
+    '--debug':                  Boolean,
+    '--multi-frames':           Boolean,
+    '--multi-frames-cpu':       Number,
+    '--reuse':                  Boolean,
 
-    '--max-memory-percent':  Number,
-    '--image-cache-percent': Number,
-    '--polling':             Number,
+    '--max-memory-percent':     Number,
+    '--image-cache-percent':    Number,
+    '--polling':                Number,
 
-    '--aerender-parameter': [String],
+    '--aerender-parameter':     [String],
 
     // Aliases
     '-v':           '--version',
+    '-t':           '--tag-selector',
     '-c':           '--cleanup',
     '-h':           '--help',
     '-s':           '--secret',
@@ -87,11 +89,13 @@ if (args['--help']) {
       -w, --workpath {underline absolute_path}          manually override path to the working directory
                                             by default nexrender is using os tmpdir/nexrender folder
 
-      -m, --wsl-map                       drive letter of your WSL mapping in Windows
+      -m, --wsl-map                         drive letter of your WSL mapping in Windows
+
+      -t, --tag-selector                    the string tags (comma delimited) to pickup the job with specific tag.
 
   {bold ADVANCED OPTIONS}
 
-
+  
     --stop-on-error                         forces worker to stop if processing/rendering error occures,
                                             otherwise worker will report an error, and continue working
 
@@ -188,6 +192,7 @@ opt('imageCachePercent',    '--image-cache-percent');
 opt('polling',              '--polling');
 opt('wslMap',               '--wsl-map');
 opt('aeParams',             '--aerender-parameter');
+opt('tagSelector',          '--tag-selector');
 
 if (args['--cleanup']) {
     settings = init(Object.assign(settings, {

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -51,6 +51,10 @@ const start = async (host, secret, settings) => {
         logger: console,
     }))
 
+    if( typeof settings.tagSelector == 'string' ){
+        settings.tagSelector = settings.tagSelector.replace(/[^a-z0-9, ]/gi, '')
+    }
+
     const client = createClient({ host, secret });
 
     do {

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -14,7 +14,12 @@ const delay = amount => (
 const nextJob = async (client, settings) => {
     do {
         try {
-            const job = await client.pickupJob();
+            let job = {};
+            if(settings.tagSelector){
+                job = await client.pickupJob(settings.tagSelector);
+            }else{
+                job = await client.pickupJob();
+            }
 
             if (job && job.uid) {
                 return job


### PR DESCRIPTION
Hi @inlife 

I'm adding a tag selector option on the worker, so the worker can pickup a job with specific tags.

For example.
If i create these job on the server

##### _Job 1_
> ![image](https://user-images.githubusercontent.com/3202529/203948712-b8346c3a-b590-43b9-93fb-3f8765614eb3.png)

##### _Job 2_
> ![image](https://user-images.githubusercontent.com/3202529/203948983-2c10a68b-5b11-47a7-aca8-d263fb54cbb0.png)

##### _Worker 1_
> ![image](https://user-images.githubusercontent.com/3202529/203949158-5a8b0a0c-fe17-464c-aa5b-21e95556ecd8.png)

##### _Worker 2_
> ![image](https://user-images.githubusercontent.com/3202529/203949266-2ea6b70a-6264-48ec-bb02-cf31692861be.png)

Explanation:  _Worker 1_ can only pick up _Job 1_ because only _Job 1_ meet the criteria (by tags).  However, _Worker 2_ can pick up _Job 1_ or _Job 2_ or any other Jobs on the server.

What do you think?