### PR TITLE
Update autofind.js to include After Effects 2023 for MacOS

### DIFF
--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -13,6 +13,7 @@ const defaultPaths = {
         '/Applications/Adobe After Effects 2020',
         '/Applications/Adobe After Effects 2021',
         '/Applications/Adobe After Effects 2022',
+        '/Applications/Adobe After Effects 2023',
         '/Applications/Adobe After Effects CC 2021',
         '/Applications/Adobe After Effects CC 2022',
         '/Applications/Adobe After Effects CC 2023',


### PR DESCRIPTION
I noticed After Effects 2023 (without CC) was missing from autofind.js. This PR adds this version for Darwin