### PR TITLE
Implement custom headers for use with API client

### DIFF
--- a/packages/nexrender-api/readme.md
+++ b/packages/nexrender-api/readme.md
@@ -37,6 +37,25 @@ const main = async () => {
 main().catch(console.error);
 ```
 
+Optionally you can provide custom headers that the API client will pass to the server on each request.
+```js
+const { createClient } = require('@nexrender/api')
+
+const client = createClient({
+    host: 'http://my.server.com:3050',
+    headers: {
+        "Some-Custom-Header": "myCustomValue",
+        "Another-Custom-Header": async () => {
+            // Perform some operations
+            return "EvaluatedValue";
+        }
+    }
+})
+```
+As shown in the example above, you can provide string value or a function that will be evaluated on each request to generate the header value dynamically. Any value that is not a string nor a function will be ignored.
+
+One should be careful when providing a function (which can be async) to generate a header value, while it does provide more flexibility than just plain strings, functions that takes a long time to resolve can negatively impact performance. For example, if an async function is defined to fetch a header value from a remote database that takes 500ms to resolve, the client will wait 500ms for the header before moving on to make the actual request, for every request. In this case you should try to memoize the function if possible so that the client doesn't have to do a full look up on each request unncessarily.
+
 ## Information
 
 Main returned function is `createClient` which allows you to create multiple clients to work with multiple endpoints in case it might be needed.

--- a/packages/nexrender-api/src/index.js
+++ b/packages/nexrender-api/src/index.js
@@ -1,9 +1,21 @@
 const fetch = require('isomorphic-unfetch')
 
-const createClient = ({ host, secret, polling }) => {
+const createClient = ({ host, secret, polling, headers }) => {
     const wrappedFetch = async (path, options) => {
         options = options || {}
-        options.headers = options.headers || {}
+
+        const defaultHeaders = {};
+        if(headers){
+            for(const [key, value] of Object.entries(headers)){
+                if(typeof value === "string"){
+                    defaultHeaders[key] = value;
+                }else if(typeof value === "function"){
+                    defaultHeaders[key] = await value();
+                }
+            }
+        }
+
+        options.headers = Object.assign(defaultHeaders, options.headers);
 
         if (secret) {
             options.headers['nexrender-secret'] = secret

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -82,6 +82,7 @@ Available settings (almost same as for `nexrender-core`):
 * `forceCommandLinePatch` - boolean, providing true will force patch re-installation
 * `stopOnError` - boolean, stop the pick-up-and-render process if an error occurs (false by default)
 * `polling` - number, amount of miliseconds to wait before checking queued projects from the api, if specified will be used instead of NEXRENDER_API_POLLING env variable
+* `header` - string, Define custom header that the worker will use to communicate with nexrender-server. Accepted format follows curl or wget request header definition, eg. `--header="Some-Custom-Header: myCustomValue"`.
 * `tagSelector` - string, (optional) provide the string tags (example `primary,plugins,halowell` : comma delimited) to pickup the job with specific tags. Leave it false to ignore and pick a random job from the server with no specific tags. Tags name must be an alphanumeric.
 * `wslMap` - string, drive letter of your WSL mapping in Windows
 * `aeParams` - array of strings, any additional params that will be passed to the aerender binary, a name-value parameter pair separated by a space,

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -35,6 +35,7 @@ const args = arg({
     '--max-memory-percent':     Number,
     '--image-cache-percent':    Number,
     '--polling':                Number,
+    '--header':                 [String],
 
     '--aerender-parameter':     [String],
 
@@ -112,6 +113,10 @@ if (args['--help']) {
 
     --polling                               amount of miliseconds to wait before checking queued projects from the api,
                                             if specified will be used instead of NEXRENDER_API_POLLING env variable
+
+    --header                                Define custom header that the worker will use to communicate with nexrender-server.
+                                            Accepted format follows curl or wget request header definition,
+                                            eg. --header="Some-Custom-Header: myCustomValue".
 
     --multi-frames                          (from Adobe site): More processes may be created to render multiple frames simultaneously,
                                             depending on system configuration and preference settings.
@@ -215,4 +220,16 @@ if (settings['no-license']) {
     settings.addLicense = true;
 }
 
-start(serverHost, serverSecret, settings);
+const headers = {};
+if (args['--header']){
+    args['--header'].forEach((header) => {
+        const [key, value] = header.split(":");
+
+        // Only set header if both header key and value are defined
+        if(key && value){
+            headers[key.trim()] = value.trim();
+        }
+    });
+}
+
+start(serverHost, serverSecret, settings, headers);

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -46,7 +46,7 @@ const nextJob = async (client, settings) => {
  * @param  {Object} settings
  * @return {Promise}
  */
-const start = async (host, secret, settings) => {
+const start = async (host, secret, settings, headers) => {
     settings = init(Object.assign({}, settings, {
         logger: console,
     }))
@@ -55,7 +55,7 @@ const start = async (host, secret, settings) => {
         settings.tagSelector = settings.tagSelector.replace(/[^a-z0-9, ]/gi, '')
     }
 
-    const client = createClient({ host, secret });
+    const client = createClient({ host, secret, headers });
 
     do {
         let job = await nextJob(client, settings); {


### PR DESCRIPTION
Resolves #821

Additional object property can be passed to the API's `createClient` argument to define custom header to use and the same is also enabled for the worker as an extra optional argument to the `start` function as well as command line argument.

Documentation are included and implementation tested on a custom setup I have. 

With the programmatic API, it is possible to define headers with functions that will be evaluated to a header value upon each request performed by the client. I would consider this advanced usage that provide lots of flexibility but shouldn't be used unless the function's implementation is sound and performant (see documentation for a bit more note).