### PR TITLE
Include assets to be cached by nexrender-action-cache

### DIFF
--- a/packages/nexrender-action-cache/index.js
+++ b/packages/nexrender-action-cache/index.js
@@ -1,72 +1,85 @@
 const fs = require('fs');
 const path = require('path');
 
-const predownload = (job, settings, { cacheDirectory, ttl }) => {
+async function findValidateCache(asset, settings, cacheDirectory, ttl){
     if (
-        !job.template.src.startsWith('http://') &&
-        !job.template.src.startsWith('https://')
+        !asset.src.startsWith('http://') &&
+        !asset.src.startsWith('https://')
     ) {
-        settings.logger.log(`> Skipping template cache; local file protocol is being used`)
-        return Promise.resolve();
+        settings.logger.log(`> Skipping cache for ${asset.src}; only http/https protocols are supported`);
+        return;
     }
-    
-    const fileName = path.basename(job.template.src);
+
+    const fileName = path.basename(asset.src);
     const maybeCachedFileLocation = path.join(cacheDirectory, fileName);
 
-    
     if (!fs.existsSync(maybeCachedFileLocation)) {
-        settings.logger.log(`> Template cache not found at ${maybeCachedFileLocation}`);
-        return Promise.resolve();
+        settings.logger.log(`> Cached file not found at ${maybeCachedFileLocation}`);
+        return;
     }
 
     if (ttl) {
         const birthtime = fs.statSync(maybeCachedFileLocation).birthtimeMs;
         if (Date.now() - birthtime > ttl) {
-            settings.logger.log(`> Template cache expired at ${maybeCachedFileLocation}`);
+            settings.logger.log(`> Cached file expired at ${maybeCachedFileLocation}`);
             settings.logger.log(`> Deleting cache at ${maybeCachedFileLocation}`);
             fs.unlinkSync(maybeCachedFileLocation);
-            return Promise.resolve();
+            return;
         }
     }
 
-    settings.logger.log(`> Template cache found at ${maybeCachedFileLocation}`);
-    settings.logger.log(`> Old template source: ${job.template.src}`);
-    job.template.src = `file://${maybeCachedFileLocation}`;
-    settings.logger.log(`> New template source: ${job.template.src}`);
-    
-    return Promise.resolve();
+    settings.logger.log(`> Cached file found at ${maybeCachedFileLocation}`);
+    settings.logger.log(`> Old source: ${asset.src}`);
+    asset.src = `file://${maybeCachedFileLocation}`;
+    settings.logger.log(`> New source: ${asset.src}`);
 }
 
-const postdownload = (job, settings, { cacheDirectory }) => {
+const predownload = async (job, settings, { cacheDirectory, ttl }) => {
+    // Job template
+    await findValidateCache(job.template, settings, cacheDirectory, ttl);
+
+    // Job assets
+    for(const asset of job.assets){
+        // Only asset types that can be downloaded files
+        if(['image', 'audio', 'video', 'script', 'static'].includes(asset.type)){
+            await findValidateCache(asset, settings, cacheDirectory, ttl);
+        }
+    }
+}
+
+async function saveCache(asset, settings, workpath, cacheDirectory){
     if (
-        !job.template.src.startsWith('http://') &&
-        !job.template.src.startsWith('https://')
+        !asset.src.startsWith('http://') &&
+        !asset.src.startsWith('https://')
     ) {
-        settings.logger.log(`> Skipping template cache; local file protocol is being used`);
-        return Promise.resolve();
+        settings.logger.log(`> Skipping cache for ${asset.src}; only http/https protocols are supported`);
+        return;
     }
 
     if (!fs.existsSync(cacheDirectory)) {
         settings.logger.log(`> Creating cache directory at ${cacheDirectory}`);
         fs.mkdirSync(cacheDirectory);
     }
-    
-    const fileName = path.basename(job.template.src);
-    settings.logger.log(`> Copying from ${path.join(job.workpath, fileName)} to ${path.join(cacheDirectory, fileName)}`);
-    const readStream = fs.createReadStream(path.join(job.workpath, fileName));
-    const writeStream = fs.createWriteStream(path.join(cacheDirectory, fileName));
 
-    return new Promise(function(resolve, reject) {
-        readStream.on('error', reject);
-        writeStream.on('error', reject);
-        writeStream.on('finish', () => resolve(job));
-        readStream.pipe(writeStream);
-    }).catch((error) => {
-        readStream.destroy();
-        writeStream.end();
-        console.log(error)
-        throw error;
-    });
+    const fileName = path.basename(asset.src);
+    const from = path.join(workpath, fileName);
+    const to = path.join(cacheDirectory, fileName);
+    settings.logger.log(`> Copying from ${from} to ${to}`);
+
+    fs.copyFileSync(from, to);
+}
+
+const postdownload = async (job, settings, { cacheDirectory }) => {
+    // Job template
+    await saveCache(job.template, settings, job.workpath, cacheDirectory);
+
+    // Job assets
+    for(const asset of job.assets){
+        // Only asset types that can be downloaded files
+        if(['image', 'audio', 'video', 'script', 'static'].includes(asset.type)){
+            await saveCache(asset, settings, job.workpath, cacheDirectory);
+        }
+    }
 }
 
 module.exports = (job, settings, { cacheDirectory, ttl }, type) => {

--- a/packages/nexrender-action-cache/index.js
+++ b/packages/nexrender-action-cache/index.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 const predownload = (job, settings, { cacheDirectory, ttl }) => {
-    if (job.template.src.startsWith('file://')) {
+    if (
+        !job.template.src.startsWith('http://') &&
+        !job.template.src.startsWith('https://')
+    ) {
         settings.logger.log(`> Skipping template cache; local file protocol is being used`)
         return Promise.resolve();
     }
@@ -35,7 +38,10 @@ const predownload = (job, settings, { cacheDirectory, ttl }) => {
 }
 
 const postdownload = (job, settings, { cacheDirectory }) => {
-    if (job.template.src.startsWith('file://')) {
+    if (
+        !job.template.src.startsWith('http://') &&
+        !job.template.src.startsWith('https://')
+    ) {
         settings.logger.log(`> Skipping template cache; local file protocol is being used`);
         return Promise.resolve();
     }

--- a/packages/nexrender-action-cache/index.js
+++ b/packages/nexrender-action-cache/index.js
@@ -34,15 +34,17 @@ async function findValidateCache(asset, settings, cacheDirectory, ttl){
     settings.logger.log(`> New source: ${asset.src}`);
 }
 
-const predownload = async (job, settings, { cacheDirectory, ttl }) => {
+const predownload = async (job, settings, { cacheDirectory, ttl, cacheAssets }) => {
     // Job template
     await findValidateCache(job.template, settings, cacheDirectory, ttl);
 
-    // Job assets
-    for(const asset of job.assets){
-        // Only asset types that can be downloaded files
-        if(['image', 'audio', 'video', 'script', 'static'].includes(asset.type)){
-            await findValidateCache(asset, settings, cacheDirectory, ttl);
+    if(cacheAssets){
+        // Job assets
+        for(const asset of job.assets){
+            // Only asset types that can be downloaded files
+            if(['image', 'audio', 'video', 'script', 'static'].includes(asset.type)){
+                await findValidateCache(asset, settings, cacheDirectory, ttl);
+            }
         }
     }
 }
@@ -69,20 +71,22 @@ async function saveCache(asset, settings, workpath, cacheDirectory){
     fs.copyFileSync(from, to);
 }
 
-const postdownload = async (job, settings, { cacheDirectory }) => {
+const postdownload = async (job, settings, { cacheDirectory, cacheAssets }) => {
     // Job template
     await saveCache(job.template, settings, job.workpath, cacheDirectory);
 
-    // Job assets
-    for(const asset of job.assets){
-        // Only asset types that can be downloaded files
-        if(['image', 'audio', 'video', 'script', 'static'].includes(asset.type)){
-            await saveCache(asset, settings, job.workpath, cacheDirectory);
+    if(cacheAssets){
+        // Job assets
+        for(const asset of job.assets){
+            // Only asset types that can be downloaded files
+            if(['image', 'audio', 'video', 'script', 'static'].includes(asset.type)){
+                await saveCache(asset, settings, job.workpath, cacheDirectory);
+            }
         }
     }
 }
 
-module.exports = (job, settings, { cacheDirectory, ttl }, type) => {
+module.exports = (job, settings, { cacheDirectory, ttl, cacheAssets }, type) => {
     if (!cacheDirectory) {
         throw new Error(`cacheDirectory not provided.`);
     }
@@ -94,11 +98,11 @@ module.exports = (job, settings, { cacheDirectory, ttl }, type) => {
     }
 
     if (type === 'predownload') {
-        return predownload(job, settings, { cacheDirectory, ttl }, type);
+        return predownload(job, settings, { cacheDirectory, ttl, cacheAssets }, type);
     }
 
     if (type === 'postdownload') {
-        return postdownload(job, settings, { cacheDirectory }, type);
+        return postdownload(job, settings, { cacheDirectory, cacheAssets }, type);
     }
 
     return Promise.resolve();

--- a/packages/nexrender-action-cache/index.js
+++ b/packages/nexrender-action-cache/index.js
@@ -2,11 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 async function findValidateCache(asset, settings, cacheDirectory, ttl){
-    if (
-        !asset.src.startsWith('http://') &&
-        !asset.src.startsWith('https://')
-    ) {
-        settings.logger.log(`> Skipping cache for ${asset.src}; only http/https protocols are supported`);
+    if (asset.src.startsWith('file://')) {
+        settings.logger.log(`> Skipping cache for ${asset.src}; local file protocol is being used`);
         return;
     }
 
@@ -50,11 +47,8 @@ const predownload = async (job, settings, { cacheDirectory, ttl, cacheAssets }) 
 }
 
 async function saveCache(asset, settings, workpath, cacheDirectory){
-    if (
-        !asset.src.startsWith('http://') &&
-        !asset.src.startsWith('https://')
-    ) {
-        settings.logger.log(`> Skipping cache for ${asset.src}; only http/https protocols are supported`);
+    if (asset.src.startsWith('file://')) {
+        settings.logger.log(`> Skipping cache for ${asset.src}; local file protocol is being used`);
         return;
     }
 

--- a/packages/nexrender-action-cache/readme.md
+++ b/packages/nexrender-action-cache/readme.md
@@ -14,6 +14,7 @@ When creating your render job provide this module in **both** of the `predownloa
 
 ## Additional Params
 - ttl (optional): a time-to-live in milliseconds for which after that the cached item is invalidated
+- cacheAssets (optional): a boolean value that if true will cache the assets used by a job as well. Note that assets with the same filename will overwrite each other in the cache so should be avoided if using assets cache.
 
 ```js
 // job.json

--- a/packages/nexrender-action-cache/test/manual.js
+++ b/packages/nexrender-action-cache/test/manual.js
@@ -1,0 +1,68 @@
+const path = require("path");
+const fs = require("fs/promises");
+const {existsSync} = require("fs");
+const assert = require("assert").strict;
+const cacheAction = require("../index.js");
+
+const cacheDirectory = path.join(__dirname, "temp");
+const workpathDirectory = path.join(__dirname, "temp_workpath");
+const ttl = 1000;
+const testJob = {
+    workpath: workpathDirectory,
+    template: {
+        src: "http://example.com/test.aep"
+    },
+    assets: [
+        {
+            "src": "https://example.com/assets/image.jpg",
+            "type": "image",
+            "layerName": "MyNicePicture.jpg"
+        }
+    ]
+};
+const settings = {
+    logger: {
+        log: console.log
+    }
+};
+
+// Predownload
+((async function(){
+    let job = JSON.parse(JSON.stringify(testJob));
+    await fs.mkdir(cacheDirectory, {recursive: true});
+
+    try{
+        await fs.writeFile(path.join(cacheDirectory, "test.aep"), "Some content");
+        await fs.writeFile(path.join(cacheDirectory, "image.jpg"), "Not an image");
+        await cacheAction(job, settings, {cacheDirectory, ttl}, "predownload");
+
+        assert.equal(job.template.src, `file://${path.join(cacheDirectory, "test.aep")}`);
+        assert.deepEqual(job.assets, [
+            {
+                "src": `file://${path.join(cacheDirectory, "image.jpg")}`,
+                "type": "image",
+                "layerName": "MyNicePicture.jpg"
+            }
+        ]);
+    }finally{
+        await fs.rm(cacheDirectory, {recursive: true, force: true});
+    }
+
+    // Postdownload
+    job = JSON.parse(JSON.stringify(testJob));
+    await fs.mkdir(cacheDirectory, {recursive: true});
+    await fs.mkdir(workpathDirectory, {recursive: true});
+
+    try{
+        await fs.writeFile(path.join(workpathDirectory, "test.aep"), "Some content");
+        await fs.writeFile(path.join(workpathDirectory, "image.jpg"), "Not an image");
+
+        await cacheAction(job, settings, {cacheDirectory, ttl}, "postdownload");
+
+        assert(existsSync(path.join(cacheDirectory, "test.aep")));
+        assert(existsSync(path.join(cacheDirectory, "image.jpg")));
+    }finally{
+        await fs.rm(cacheDirectory, {recursive: true, force: true});
+        await fs.rm(workpathDirectory, {recursive: true, force: true});
+    }
+})());

--- a/packages/nexrender-action-cache/test/manual.js
+++ b/packages/nexrender-action-cache/test/manual.js
@@ -34,7 +34,7 @@ const settings = {
     try{
         await fs.writeFile(path.join(cacheDirectory, "test.aep"), "Some content");
         await fs.writeFile(path.join(cacheDirectory, "image.jpg"), "Not an image");
-        await cacheAction(job, settings, {cacheDirectory, ttl}, "predownload");
+        await cacheAction(job, settings, {cacheDirectory, ttl, cacheAssets: true}, "predownload");
 
         assert.equal(job.template.src, `file://${path.join(cacheDirectory, "test.aep")}`);
         assert.deepEqual(job.assets, [
@@ -57,7 +57,7 @@ const settings = {
         await fs.writeFile(path.join(workpathDirectory, "test.aep"), "Some content");
         await fs.writeFile(path.join(workpathDirectory, "image.jpg"), "Not an image");
 
-        await cacheAction(job, settings, {cacheDirectory, ttl}, "postdownload");
+        await cacheAction(job, settings, {cacheDirectory, ttl, cacheAssets: true}, "postdownload");
 
         assert(existsSync(path.join(cacheDirectory, "test.aep")));
         assert(existsSync(path.join(cacheDirectory, "image.jpg")));


### PR DESCRIPTION
Addresses #834 (Don't want to close the original issue yet)

Implemented assets caching with `nexrender-action-cache` and by providing the extra boolean `cacheAssets` option to the action definition assets as well as job template will be cached locally. One of the reason this is optional is because if more than one assets have the same name, they will overwrite each other in the cache directory. It could be possible to use the full URL as the filename to prevent unintended overwriting but it is complicated in other ways. 

As such I'm not entirely satisfied with this implementation but I don't think it is possible to build out what I'd prefer with `nexrender-action-cache` while preserving backwards compatibility. So I'm going to leave `nexrender-action-cache` at this point and build out another idea for cache in a different package.