### PR TITLE
HTTP caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Second one is responsible for mainly job-related operations of the full cycle: d
 * `forceCommandLinePatch` - boolean, providing true will force patch re-installation
 * `wslMap` - String, set WSL drive map, check [wsl](#wsl) for more info
 * `maxRenderTimeout` - Number, set max render timeout in seconds, will abort rendering if it takes longer than this value (default: 0 - disabled)
+* `cache` - boolean or string. Set the cache folder used by HTTP assets. If `true` will use the default path of `${workpath}/http-cache`, if set to a string it will be interpreted as a filesystem path to the cache folder.
 
 More info: [@nexrender/core](packages/nexrender-core)
 
@@ -577,6 +578,40 @@ This way you (if you are using network rendering) can not only deliver assets to
             "type": "audio",
             "name": "music.mp3",
             "layerIndex": 15
+        }
+    ]
+}
+```
+
+### HTTP caching
+When using the `http` or `https` protocol, you can utilize local caching to minimize the amount of data that have to be transferred over a network and speed up project/assets download. To use HTTP caching, the server serving your assets must support the relevant [HTTP caching semantics](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching).
+
+The simplest way to enable caching is to use the setting wide cache option (setting`--cache` flag if using CLI or worker CLI, setting `cache: true` when using programmatically). This will enable HTTP based caching for all your assets and project files if they are requested over HTTP from a server that supports the relevant headers.
+
+You can also control caching on a more granular level if desired. For each asset's setting if a `params` property is set, it will be passed directly to [make-fetch-happen](https://github.com/npm/make-fetch-happen) which includes the `cachePath` property that you can set to a custom folder path (or null if you want to disable caching for a particular asset only).
+
+> Note: caches are not cleared automatically so you may need to monitor the cache folder size if you are using a lot of large assets over time. Assets, if they have been cached, will always resolve even if they are stale and the server is not available.
+
+### Example
+```json
+{
+    "assets": [
+        {
+            "src": "https://example.com/assets/image.jpg",
+            "type": "image",
+            "layerName": "MyNicePicture.jpg",
+            "params": {
+                "cachePath": "/tmp/my-nexrender-cache"
+            }
+        },
+        {
+            "src": "https://example.com/assets/jpeg-without-extension",
+            "type": "image",
+            "layerName": "MyOtherNicePicture.jpg",
+            "extension": "jpg",
+            "params": {
+                "cachePath": "/tmp/my-nexrender-cache"
+            }
         }
     ]
 }

--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -17,6 +17,8 @@ const args = arg({
     '--binary':     String,
     '--workpath':   String,
     '--wsl-map':    String,
+    '--cache':      Boolean,
+    '--cache-path': String,
 
     '--stop-on-error':  Boolean,
 
@@ -83,8 +85,15 @@ if (args['--help']) {
 
       -m, --wsl-map                         drive letter of your WSL mapping in Windows
 
+
   {bold ADVANCED OPTIONS}
 
+
+    --cache                                 Boolean flag that enables default HTTP caching of assets.
+                                            Will save cache to [workpath]/http-cache unless "--cache-path is used"
+
+    --cache-path                            String value that sets the HTTP cache path to the provided folder path.
+                                            "--cache" will default to true if this is used.
 
     --stop-on-error                         forces worker to stop if processing/rendering error occures,
                                             otherwise worker will report an error, and continue working
@@ -167,6 +176,12 @@ opt('maxMemoryPercent',     '--max-memory-percent');
 opt('imageCachePercent',    '--image-cache-percent');
 opt('wslMap',               '--wsl-map');
 opt('aeParams',             '--aerender-parameter');
+
+if(args['--cache-path']){
+    opt('cache', '--cache-path');
+}else if(args['--cache']){
+    opt('cache', '--cache');
+}
 
 /* debug implies verbose */
 settings.verbose = settings.debug;

--- a/packages/nexrender-core/package.json
+++ b/packages/nexrender-core/package.json
@@ -14,7 +14,7 @@
     "match-all": "^1.2.5",
     "mime-types": "^2.1.29",
     "mkdirp": "^1.0.4",
-    "node-fetch": "^2.6.7",
+    "make-fetch-happen": "^11.0.2",
     "requireg": "^0.2.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/nexrender-core/readme.md
+++ b/packages/nexrender-core/readme.md
@@ -72,3 +72,4 @@ Second one is responsible for mainly job-related operations of the full cycle: d
 * `forceCommandLinePatch` - boolean, providing true will force patch re-installation
 * `onInstanceSpawn` - a callback, if provided, gets called when **aerender** instance is getting spawned, with instance pointer. Can be later used to kill a hung aerender process. Callback signature: `function (instance, job, settings) {}`
 * `actions` - an object with keys corresponding to the `module` field when defining an action, value should be a function matching expected signature of an action. Used for defining actions programmatically without needing to package the action as a separate package
+* `cache` - boolean or string. Set the cache folder used by HTTP assets. If `true` will use the default path of `${workpath}/http-cache`, if set to a string it will be interpreted as a filesystem path to the cache folder.

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -87,4 +87,5 @@ Available settings (almost same as for `nexrender-core`):
 * `wslMap` - string, drive letter of your WSL mapping in Windows
 * `aeParams` - array of strings, any additional params that will be passed to the aerender binary, a name-value parameter pair separated by a space,
 * `actions` - an object with keys corresponding to the `module` field when defining an action, value should be a function matching expected signature of an action. Used for defining actions programmatically without needing to package the action as a separate package
+* `cache` - boolean or string. Set the cache folder used by HTTP assets. If `true` will use the default path of `${workpath}/http-cache`, if set to a string it will be interpreted as a filesystem path to the cache folder.
 

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -20,6 +20,8 @@ const args = arg({
     '--workpath':               String,
     '--wsl-map':                String,
     '--tag-selector':           String,
+    '--cache':                  Boolean,
+    '--cache-path':             String,
 
     '--stop-on-error':          Boolean,
 
@@ -96,7 +98,13 @@ if (args['--help']) {
 
   {bold ADVANCED OPTIONS}
 
-  
+
+    --cache                                 Boolean flag that enables default HTTP caching of assets.
+                                            Will save cache to [workpath]/http-cache unless "--cache-path is used"
+
+    --cache-path                            String value that sets the HTTP cache path to the provided folder path.
+                                            "--cache" will default to true if this is used.
+
     --stop-on-error                         forces worker to stop if processing/rendering error occures,
                                             otherwise worker will report an error, and continue working
 
@@ -198,6 +206,12 @@ opt('polling',              '--polling');
 opt('wslMap',               '--wsl-map');
 opt('aeParams',             '--aerender-parameter');
 opt('tagSelector',          '--tag-selector');
+
+if(args['--cache-path']){
+    opt('cache', '--cache-path');
+}else if(args['--cache']){
+    opt('cache', '--cache');
+}
 
 if (args['--cleanup']) {
     settings = init(Object.assign(settings, {


### PR DESCRIPTION
Resolves #834

Implement HTTP caching support for assets and project files using make-fetch-happen. Server will need to implement the relevant headers and handle relevant requests appropriately for it to work fully (since the server is the one that actually knows if a file has changed or not).

I've not fully tested this as I don't have a working rendering environment at the moment, so it may be good to test this out first to ensure I didn't get anything wrong.