### PR TITLE
Fix to trim(s) in commandLineRenderer from 2023

### DIFF
--- a/packages/nexrender-core/src/assets/commandLineRenderer-2022.jsx
+++ b/packages/nexrender-core/src/assets/commandLineRenderer-2022.jsx
@@ -254,7 +254,7 @@ function AECommandLineRenderer() {
 
         // ExtendScript too old to have str.trim(), replace when it does
         function trim(s) {
-            return s.replace(/^\s+|\s+$/g, '');
+            return s.replace(/^s+|s+$/g, '');
         }
 
         for (var i in keyValuePairs) {


### PR DESCRIPTION
Did a diff to solve another problem and found this little bugfix. 
Very relevant for the new -renderSettings and -outputSettings flags, as it trims whitespace which allows for greater tolerance for the parameter strings.