### PR TITLE
fix: Gif output

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -147,9 +147,9 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
 
         case 'gif':
             params = Object.assign({}, {
-                '-i': inputs,
                 '-ss': '61.0',
                 '-t': '2.5',
+                '-i': inputs,
                 '-filter_complex': `[0:v] fps=12,scale=480:-1,split [a][b];[a] palettegen [p];[b][p] paletteuse`,
             }, params, {
                 '-y': output

--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -147,10 +147,8 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
 
         case 'gif':
             params = Object.assign({}, {
-                '-ss': '61.0',
-                '-t': '2.5',
                 '-i': inputs,
-                '-filter_complex': `[0:v] fps=12,scale=480:-1,split [a][b];[a] palettegen [p];[b][p] paletteuse`,
+                '-filter_complex': `[0:v] fps=12,scale=w=480:h=-1,split [a][b];[a] palettegen [p];[b][p] paletteuse`,
             }, params, {
                 '-y': output
             });


### PR DESCRIPTION
Gifs won't output in most cases because of extraneous ffmpeg arguments that trim the clip. This removes them