### PR TITLE
Added onFinish and onError

### DIFF
--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -60,6 +60,8 @@ const main = async () => {
         },
         onRenderProgress: function(job) {},
         onRenderError: function(job, err) {},
+        onFinished: function(job) {},
+        onError: function(job, err) {},
     })
 }
 


### PR DESCRIPTION
I've added Callback like onFinished and onError.

The current implement onRenderingProgress won't be called if the project has been finished, so onFinished can be helpful there.

onRenderError only throws the error regarding rendering, the  onError functions throws all other errors.