### PR TITLE
exit with exit code 1 on aerender failure for CLI

### DIFF
--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -251,4 +251,5 @@ nexrender.render(parsedJob, settings)
     .catch(err => {
         console.error('> job rendering failed')
         console.error(err)
+        process.exit(1);
     })


### PR DESCRIPTION
I have a use case to know whether a job has failed or not based on the exit code of nexrender. It's pretty standard for a CLI to return an error code of non-zero for a failure. 