### PR TITLE
fix(core): use `-mfr` only for cc2022+

### DIFF
--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -75,7 +75,16 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
 
     option(params, '-r', jobScriptFile);
 
-    if (!settings.skipRender && settings.multiFrames) params.push('-mfr', 'ON', settings.multiFramesCPU);
+    if (!settings.skipRender && settings.multiFrames) {
+        const afterEffects = path.dirname(settings.binary)
+        const afterEffectsYearMatch = afterEffects.match(/(20[0-9]{2})/);
+
+        if (afterEffectsYearMatch && afterEffectsYearMatch[0] >= "2022") {
+            params.push('-mfr', 'ON', settings.multiFramesCPU);
+        } else {
+            params.push('-mp');
+        }
+    }
     if (settings.reuse) params.push('-reuse');
     if (job.template.continueOnMissing) params.push('-continueOnMissingFootage')
 


### PR DESCRIPTION
This fixes a regression introduced in the PR #656 two years ago, it causes invalid argument `-mfr` error when trying to render with aerender version older than 2022.

In #656 @chrisapplegate added new `commandLineRenderer-2022.jsx` for AE 2022+, and kept `commandLineRenderer-default.jsx` for pre-2022, they were patched correctly. But Chris forgot to check the version and applied the cc2022-only argument `-mfr` in all cases, resulting a regression.

It seems this regression has lasted a long time and no one noticed. Recently I tried to upgrade the dependencies of my project which stays at using old version of aerender and found that a `-mfr` error throws when I update `@nexrender/core` to any version greater then 1.32.x. #656 was shipped in 1.33.0, all versions of `@nexrender/core` starting from 1.33.0 are buggy.