### PR TITLE
Retry On Error

### DIFF
--- a/packages/nexrender-core/src/helpers/errors.js
+++ b/packages/nexrender-core/src/helpers/errors.js
@@ -1,7 +1,8 @@
-class RenderError extends Error {
-    constructor(code, message) {
+class RenderProcessError extends Error {
+    constructor(code, signal, message) {
         super();
         this.code = code;
+        this.signal = signal;
         this.message = message;
     }
 }

--- a/packages/nexrender-core/src/helpers/errors.js
+++ b/packages/nexrender-core/src/helpers/errors.js
@@ -1,0 +1,7 @@
+class RenderError extends Error {
+    constructor(code, message) {
+        super();
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -233,7 +233,7 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
             const outputStr = output
                 .map(a => '' + a).join('');
 
-            if (code !== 0 && settings.stopOnError) {
+            if (code !== 0) {
                 if (fs.existsSync(logPath)) {
                     settings.logger.log(`[${job.uid}] dumping aerender log:`)
                     settings.logger.log(fs.readFileSync(logPath, 'utf8'))
@@ -246,7 +246,7 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
                 });
 
                 clearTimeout(timeoutID);
-                return reject(new Error(outputStr || 'aerender.exe failed to render the output into the file due to an unknown reason'));
+                return reject(new RenderError(code, outputStr || 'aerender.exe failed to render the output into the file due to an unknown reason'));
             }
 
             const renderTime = (Date.now() - renderStopwatch) / 1000

--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -116,9 +116,9 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
     const parse = (data) => {
         const string = ('' + data).replace(/;/g, ':'); /* sanitize string */
 
-        // Only execute startRegex if project start hasnt been found
+        // Only execute startRegex if project start hasn't been found
         const matchStart = isNaN(parseInt(projectStart)) ? startRegex.exec(string) : false;
-        // Only execute durationRegex if project duration hasnt been found
+        // Only execute durationRegex if project duration hasn't been found
         const matchDuration = isNaN(parseInt(projectDuration)) ? durationRegex.exec(string) : false;
         // Only execute progressRegex if project duration has been found
         const matchProgress = !isNaN(parseInt(projectDuration)) ? progressRegex.exec(string) : null;
@@ -228,7 +228,7 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
         }
 
         /* on finish (code 0 - success, other - error) */
-        instance.on('close', (code) => {
+        instance.on('close', (code, signal) => {
 
             const outputStr = output
                 .map(a => '' + a).join('');
@@ -246,7 +246,7 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
                 });
 
                 clearTimeout(timeoutID);
-                return reject(new RenderError(code, outputStr || 'aerender.exe failed to render the output into the file due to an unknown reason'));
+                return reject(new RenderProcessError(code, signal, outputStr || 'aerender.exe failed to render the output into the file due to an unknown reason'));
             }
 
             const renderTime = (Date.now() - renderStopwatch) / 1000

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -62,6 +62,7 @@ const main = async () => {
         onRenderError: function(job, err) {},
         onFinished: function(job) {},
         onError: function(job, err) {},
+        onShouldRetry: function (job, err) { return false; },
     })
 }
 


### PR DESCRIPTION
Occasionally the render process fails, and it would be desirable to allow the render to immediately try again under certain conditions, such as `aerender` exiting with a non-zero exit code.

This PR adds the ability for the user to supply a custom `onShouldRetry` function to trigger a retry as required.