### PR TITLE
fixbug ReferenceError: init is not defined

### DIFF
--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -202,7 +202,7 @@ if (settings['no-analytics']) {
 }
 
 if (args['--cleanup']) {
-    settings = init(Object.assign(settings, {
+    settings = nexrender.init(Object.assign(settings, {
         logger: console
     }))
 


### PR DESCRIPTION
usage: ./nexrender-cli-macos -c

error: 
pkg/prelude/bootstrap.js:1926
      return wrapper.apply(this.exports, args);
                     ^
ReferenceError: init is not defined
    at Object.<anonymous> (/snapshot/nexrender/packages/nexrender-cli/src/bin.js)
    at Module._compile (pkg/prelude/bootstrap.js:1926:22)
    at Module._extensions..js (node:internal/modules/cjs/loader:1166:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:834:12)
    at Function.runMain (pkg/prelude/bootstrap.js:1979:12)
    at node:internal/main/run_main_module:17:47

Node.js v18.5.0