### PR TITLE
Use the label Stale for stale issues instead of wontfix

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
It's my impression that generally the label wontfix is used on github for issues where the maintainer has actively decided that an issue should not be fixed, and not simply for an issue that has not received attention. This is a bit confusing when looking at issues in the nexrender repo and I propose to change it to apply the label stale.

Issues with the label wontfix will deter contributors from working on them. 