### PR TITLE
Solve issue with EnhancedScript.prototype.findMissingMatchesInJSX only reporting parameter 't' as missing. Fixes #716

### DIFF
--- a/packages/nexrender-core/src/tasks/script.js
+++ b/packages/nexrender-core/src/tasks/script.js
@@ -273,7 +273,7 @@ const wrapEnhancedScript = (job, settings, { dest, src, parameters = [], keyword
         const script = this.stripCommentsFromScript(this.getJSXScript());
 
         // Parse all occurrences of the usage of NX on the provided script.
-        const nxMatches = matchAll(script, this.getRegex("searchUsageByMethod")("get", "gm")).toArray();
+        const nxMatches = [...script.matchAll(this.getRegex("searchUsageByMethod")("get", "gm"))];
 
         if (nxMatches && nxMatches.length > 0 ) {
             nxMatches.forEach( match => {


### PR DESCRIPTION
Seems this method is written with the expectation that matchAll (https://github.com/IonicaBizau/match-all/) is returning a nested array with capture groups. Maybe it has done before? Atleast it doesn't now. Using the native string.matchAll makes the remaining method work as expected printing warnings for the appropriate parameters that are accessed with NX.get but does not have values defined in the job. 

Not sure if there are other places where the use of the matchAll package may be causing similar issues - did not test with anything else than parameters.

I could make a PR to replace all uses of match-all with native string.matchAll unless you are aware of some edge cases where the library is solving some issue - may be on certain platforms? 