### PR TITLE
Fix missing path for MacOS After Effects 2024 in autofind.js

### DIFF
--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -14,6 +14,7 @@ const defaultPaths = {
         '/Applications/Adobe After Effects 2021',
         '/Applications/Adobe After Effects 2022',
         '/Applications/Adobe After Effects 2023',
+        '/Applications/Adobe After Effects 2024',
         '/Applications/Adobe After Effects CC 2021',
         '/Applications/Adobe After Effects CC 2022',
         '/Applications/Adobe After Effects CC 2023',


### PR DESCRIPTION
```
Error: you should provide a proper path to After Effects' "aerender" binary
    at init (/snapshot/nexrender/packages/nexrender-core/src/index.js)
    at start (/snapshot/nexrender/packages/nexrender-worker/src/index.js)
    at Object.<anonymous> (/snapshot/nexrender/packages/nexrender-worker/src/bin.js)
    at Module._compile (pkg/prelude/bootstrap.js:1926:22)
    at Module._extensions..js (node:internal/modules/cjs/loader:1166:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:834:12)
    at Function.runMain (pkg/prelude/bootstrap.js:1979:12)
    at node:internal/main/run_main_module:17:47
```

I've added 'After Effects 2024' to darwin.

When start nexrender on MacOS, an error message appears.

I noticed that 'After Effects 2024' is missing from the array.