### PR TITLE
Fix | nexrender-action-encode | valueless ffmpeg params

### DIFF
--- a/packages/nexrender-action-encode/index.js
+++ b/packages/nexrender-action-encode/index.js
@@ -1,13 +1,13 @@
-const fs = require('fs')
-const path = require('path')
-const pkg = require('./package.json')
-const fetch = require('node-fetch')
-const { spawn } = require('child_process')
-const nfp = require('node-fetch-progress')
+const fs      = require('fs')
+const path    = require('path')
+const pkg     = require('./package.json')
+const fetch   = require('node-fetch')
+const {spawn} = require('child_process')
+const nfp     = require('node-fetch-progress')
 
 const getBinary = (job, settings) => {
     return new Promise((resolve, reject) => {
-        const { version } = pkg['ffmpeg-static']
+        const {version} = pkg['ffmpeg-static']
         const filename = `ffmpeg-${version}${process.platform == 'win32' ? '.exe' : ''}`
         const fileurl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${version}/${process.platform}-x64`
         const output = path.join(settings.workpath, filename)
@@ -27,7 +27,7 @@ const getBinary = (job, settings) => {
 
         const errorHandler = (error) => reject(new Error({
             reason: 'Unable to download file',
-            meta: { fileurl, error }
+            meta: {fileurl, error}
         }))
 
 
@@ -36,9 +36,9 @@ const getBinary = (job, settings) => {
                 ? res
                 : Promise.reject(new Error({
                     reason: 'Initial error downloading file',
-                    meta: { fileurl, error: res.error }
+                    meta: {fileurl, error: res.error}
                 })
-                ))
+            ))
             .then(res => {
                 const progress = new nfp(res)
 
@@ -97,17 +97,17 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
         '-ar': '44100',
     };
 
-    switch (preset) {
+    switch(preset) {
         case 'mp4':
             params = Object.assign(baseParams, {
                 '-acodec': 'aac',
                 '-vcodec': 'libx264',
-                '-pix_fmt': 'yuv420p',
+                '-pix_fmt' : 'yuv420p',
                 '-r': '25',
             }, params, {
-                '-y': output
+              '-y': output
             });
-            break;
+        break;
 
         case 'ogg':
             params = Object.assign(baseParams, {
@@ -117,7 +117,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             }, params, {
                 '-y': output
             });
-            break;
+        break;
 
         case 'webm':
             params = Object.assign(baseParams, {
@@ -128,7 +128,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             }, params, {
                 '-y': output
             });
-            break;
+        break;
 
         case 'mp3':
             params = Object.assign(baseParams, {
@@ -136,7 +136,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             }, params, {
                 '-y': output
             });
-            break;
+        break;
 
         case 'm4a':
             params = Object.assign(baseParams, {
@@ -146,7 +146,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             }, params, {
                 '-y': output
             });
-            break;
+        break;
 
         case 'gif':
             params = Object.assign({}, {
@@ -155,7 +155,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             }, params, {
                 '-y': output
             });
-            break;
+        break;
 
         default:
             params = Object.assign({}, {
@@ -163,7 +163,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
             }, params, {
                 '-y': output
             });
-            break;
+        break;
     }
 
     /* convert key-value pair to array */
@@ -189,7 +189,7 @@ const constructParams = (job, settings, { preset, input, output, params }) => {
     );
 }
 
-const convertToMilliseconds = (h, m, s) => ((h * 60 * 60 + m * 60 + s) * 1000);
+const convertToMilliseconds = (h, m, s) => ((h*60*60+m*60+s)*1000);
 
 const getDuration = (regex, data) => {
     const matches = data.match(regex);
@@ -210,7 +210,7 @@ module.exports = (job, settings, options/*, type */) => {
             if (settings.debug) {
                 settings.logger.log(`[${job.uid}] spawning ffmpeg process: ${binary} ${params.join(' ')}`);
             }
-            const instance = spawn(binary, params, { windowsHide: true });
+            const instance = spawn(binary, params, {windowsHide: true});
             let totalDuration = 0
 
             instance.on('error', err => reject(new Error(`Error starting ffmpeg process: ${err}`)));

--- a/packages/nexrender-action-encode/readme.md
+++ b/packages/nexrender-action-encode/readme.md
@@ -38,37 +38,12 @@ When creating your render job provide this module as one of the `postrender` act
 }
 ```
 
-
-
 ## Information
 
 * `output` is a path on your system where result will be saved to, can be either relative or absulte path.
 * `input` optional argument, path of the file you want to encode, can be either relative or absulte path. Defaults to current job output video file.
 * `preset` optional argument, if provided will be used as a preset for the renderer, if not, will take input directly from params
 * `params` optional argument, object containing additional params that will be provided to the ffmpeg binary
-### Params (optional)
-Params are passed as an object of key-value pairs. In case of a param without value, you can provide `null` or empty string `""` as a value.
-Eg. `{"-vcodec": "libx264", "-r": 25, "-an": null}` would end up as `-vcodec libx264 -r 25 -an` in the final ffmpeg command.
-
-```json
-// job.json
-{
-    "actions": {
-        "postrender": [
-            {
-                "module": "@nexrender/action-encode",
-                "output": "foobar.mp4",
-                "preset": "mp4",
-                "params": {
-                    "-vcodec": "libx264", 
-                    "-r": 25,
-                    "-an": null, // disable audio
-                }
-            }
-        ]
-    }
-}
-```
 
 ## Presets
 

--- a/packages/nexrender-action-encode/readme.md
+++ b/packages/nexrender-action-encode/readme.md
@@ -38,12 +38,37 @@ When creating your render job provide this module as one of the `postrender` act
 }
 ```
 
+
+
 ## Information
 
 * `output` is a path on your system where result will be saved to, can be either relative or absulte path.
 * `input` optional argument, path of the file you want to encode, can be either relative or absulte path. Defaults to current job output video file.
 * `preset` optional argument, if provided will be used as a preset for the renderer, if not, will take input directly from params
 * `params` optional argument, object containing additional params that will be provided to the ffmpeg binary
+### Params (optional)
+Params are passed as an object of key-value pairs. In case of a param without value, you can provide `null` or empty string `""` as a value.
+Eg. `{"-vcodec": "libx264", "-r": 25, "-an": null}` would end up as `-vcodec libx264 -r 25 -an` in the final ffmpeg command.
+
+```json
+// job.json
+{
+    "actions": {
+        "postrender": [
+            {
+                "module": "@nexrender/action-encode",
+                "output": "foobar.mp4",
+                "preset": "mp4",
+                "params": {
+                    "-vcodec": "libx264", 
+                    "-r": 25,
+                    "-an": null, // disable audio
+                }
+            }
+        ]
+    }
+}
+```
 
 ## Presets
 


### PR DESCRIPTION
The problem this pull request solves is when you input a valueless param in job settings (for example `-an`). I've tried empty string which results with a double space in the final command.

The rest is explained in the readme change and comments