### PR TITLE
added tif support for render image sequences

### DIFF
--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -256,7 +256,7 @@ Estimated date of change to the new behavior: 2023-06-01.\n`);
             fs.writeFileSync(logPath, outputStr);
 
             /* resolve job without checking if file exists, or its size for image sequences */
-            if (settings.skipRender || job.template.imageSequence || ['jpeg', 'jpg', 'png'].indexOf(outputFile) !== -1) {
+            if (settings.skipRender || job.template.imageSequence || ['jpeg', 'jpg', 'png', 'tif'].indexOf(outputFile) !== -1) {
                 settings.track('Job Render Finished', {
                     job_id: job.uid, // anonymized internally
                     job_finish_reason: 'skipped_check',

--- a/packages/nexrender-core/src/tasks/setup.js
+++ b/packages/nexrender-core/src/tasks/setup.js
@@ -36,7 +36,7 @@ An example of how that might look like: { "outputModule": "h264", "outputExt": "
     }
 
     // NOTE: for still (jpg) image sequence frame filename will be changed to result_[#####].jpg
-    if (job.template.outputExt && ['jpeg', 'jpg', 'png'].indexOf(job.template.outputExt) !== -1) {
+    if (job.template.outputExt && ['jpeg', 'jpg', 'png', 'tif'].indexOf(job.template.outputExt) !== -1) {
         job.resultname = 'result_[#####].' + job.template.outputExt;
         job.template.imageSequence = true;
     }


### PR DESCRIPTION
When rendering TIF images, there was a problem with locating the final file. Since TIF generates file sequences, there were issues with file naming, and the render would fail. Now, everything looks great