### PR TITLE
Refactor error handling in file download task

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -86,7 +86,7 @@ const download = (job, settings, asset) => {
             /* TODO: maybe move to external package ?? */
             const src = asset.src
             return fetch(src, asset.params)
-                .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {src, error: res.error}}))
+                .then(res => res.ok ? res : Promise.reject(new Error(`Unable to download file ${src}`)))
                 .then(res => {
                     // Set a file extension based on content-type header if not already set
                     if (!asset.extension) {


### PR DESCRIPTION
The error handling in the file downloading task of nexrender-core has been refactored. Instead of rejecting with an object containing a complex error message and metadata, a simple error message in string format is now used, allowing nexrender-worker to log asset download errors.