### PR TITLE
Resolve issue https://github.com/inlife/nexrender/issues/1003

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -25,10 +25,8 @@ const download = (job, settings, asset) => {
         /* ^ remove possible query search string params ^ */
         destName = decodeURI(destName) /* < remove/decode any special URI symbols within filename */
 
-        /* prevent same name file collisions */
-        if (fs.existsSync(path.join(job.workpath, destName))) {
-            destName = Math.random().toString(36).substring(2) + path.extname(asset.src).split('?')[0];
-        }
+        /* prevent duplicate filename collisions during parallel fetch */
+        destName = Math.random().toString(36).substring(2) + '-' + destName;
     }
 
     /* force asset name if it is provided */


### PR DESCRIPTION
Always randomize filenames for parallel downloads.

Fixes #1003 