### PR TITLE
Added --stop-at-time and --stop-days arguments

### DIFF
--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -130,7 +130,8 @@ if (args['--help']) {
                                             example: 5:00 will stop at 5 am local time.  
     
     --stop-days                             comma separated list of weekdays when to stop. Must be used together with --stop-at-time
-                                            example: --stop-at-time=5:00 stop-days=0,1,2,3,4
+                                            0 is sunday, 6 is saturday
+                                            example: --stop-at-time=5:00 stop-days=1,2,3,4,5
                                             will stop at 5 am but not on weekend                                          
                                             
     --no-license                            prevents creation of the ae_render_only_node.txt file (enabled by default),

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -27,6 +27,8 @@ const args = arg({
     '--stop-on-error':          Boolean,
     '--exit-on-empty-queue':    Boolean,
     '--tolerate-empty-queues':  Number,
+    '--stop-at-time':           String,
+    '--stop-days':              String,
 
     '--skip-cleanup':           Boolean,
     '--skip-render':            Boolean,
@@ -123,7 +125,14 @@ if (args['--help']) {
     --tolerate-empty-queues                 worker will check an empty queue this many times before exiting (if that option has
                                             been set using --exit-on-empty-queues). Defaults to zero. If specified will be used instead of
                                             NEXRENDER_TOLERATE_EMPTY_QUEUES env variable
-
+                                            
+    --stop-at-time                          worker will exit at the given time if given.
+                                            example: 5:00 will stop at 5 am local time.  
+    
+    --stop-days                             comma separated list of weekdays when to stop. Must be used together with --stop-at-time
+                                            example: --stop-at-time=5:00 stop-days=0,1,2,3,4
+                                            will stop at 5 am but not on weekend                                          
+                                            
     --no-license                            prevents creation of the ae_render_only_node.txt file (enabled by default),
                                             which allows free usage of trial version of Adobe After Effects
 
@@ -219,6 +228,8 @@ opt('reuse',                '--reuse');
 opt('stopOnError',          '--stop-on-error');
 opt('tolerateEmptyQueues',  '--tolerate-empty-queues');
 opt('exitOnEmptyQueue',     '--exit-on-empty-queue');
+opt('stopAtTime',           '--stop-at-time');
+opt('stopDays',             '--stop-days');
 opt('maxMemoryPercent',     '--max-memory-percent');
 opt('imageCachePercent',    '--image-cache-percent');
 opt('polling',              '--polling');

--- a/packages/nexrender-worker/src/instance.js
+++ b/packages/nexrender-worker/src/instance.js
@@ -12,10 +12,16 @@ const createWorker = () => {
     let emptyReturns = 0;
     let active = false;
     let settingsRef = null;
+    let stop_datetime = null;
 
     const nextJob = async (client, settings) => {
         do {
             try {
+                if (stop_datetime !== null && new Date() > stop_datetime) {
+                    active = false;
+                    return
+                }
+
                 let job = await (settings.tagSelector ?
                     await client.pickupJob(settings.tagSelector) :
                     await client.pickupJob()
@@ -89,7 +95,6 @@ const createWorker = () => {
             worker_setting_stop_on_error: settings.stopOnError,
         })
 
-        let stop_datetime = null;
         if(settings.stopAtTime) {
             let stopTimeParts = settings.stopAtTime.split(':'); // split the hour and minute
             let now = new Date(); // get current date object
@@ -110,10 +115,6 @@ const createWorker = () => {
         }
 
         do {
-            if (stop_datetime !== null && new Date() > stop_datetime) {
-                active = false;
-                break;
-            }
 
             let job = await nextJob(client, settings);
 

--- a/packages/nexrender-worker/src/instance.js
+++ b/packages/nexrender-worker/src/instance.js
@@ -94,24 +94,26 @@ const createWorker = () => {
             let stopTimeParts = settings.stopAtTime.split(':'); // split the hour and minute
             let now = new Date(); // get current date object
 
-            let stopTimeDate = new Date(); // new date object for stopping time
-            stopTimeDate.setHours(stopTimeParts[0], stopTimeParts[1], 0, 0); // set the stop time
+            stop_datetime = new Date(); // new date object for stopping time
+            stop_datetime.setHours(stopTimeParts[0], stopTimeParts[1], 0, 0); // set the stop time
 
-            if(stopTimeDate.getTime() <= now.getTime()){
-                stopTimeDate.setDate(stopTimeDate.getDate() + 1); // if it's past the stop time, move it to next day
+            if(stop_datetime.getTime() <= now.getTime()){
+                stop_datetime.setDate(stop_datetime.getDate() + 1); // if it's past the stop time, move it to next day
             }
 
-            stop_datetime = stopTimeDate;
             if(settings.stopDays) {
-                    let stopDaysList = settings.stopDays.split(',').map(Number); // convert string weekdays into integer values
-                    while(!stopDaysList.includes(stop_datetime.getDay())) {
-                        stop_datetime.setDate(stop_datetime.getDate() + 1); // if stop_datetime's weekday is not in the list, add one day
-                    }
+                let stopDaysList = settings.stopDays.split(',').map(Number); // convert string weekdays into integer values
+                while(!stopDaysList.includes(stop_datetime.getDay())) {
+                    stop_datetime.setDate(stop_datetime.getDate() + 1); // if stop_datetime's weekday is not in the list, add one day
+                }
             }
         }
 
         do {
-            if (stop_datetime !== null && new Date() > stop_datetime) { active = false; break; }
+            if (stop_datetime !== null && new Date() > stop_datetime) {
+                active = false;
+                break;
+            }
 
             let job = await nextJob(client, settings);
 

--- a/packages/nexrender-worker/src/instance.js
+++ b/packages/nexrender-worker/src/instance.js
@@ -89,7 +89,30 @@ const createWorker = () => {
             worker_setting_stop_on_error: settings.stopOnError,
         })
 
+        let stop_datetime = null;
+        if(settings.stopAtTime) {
+            let stopTimeParts = settings.stopAtTime.split(':'); // split the hour and minute
+            let now = new Date(); // get current date object
+
+            let stopTimeDate = new Date(); // new date object for stopping time
+            stopTimeDate.setHours(stopTimeParts[0], stopTimeParts[1], 0, 0); // set the stop time
+
+            if(stopTimeDate.getTime() <= now.getTime()){
+                stopTimeDate.setDate(stopTimeDate.getDate() + 1); // if it's past the stop time, move it to next day
+            }
+
+            stop_datetime = stopTimeDate;
+            if(settings.stopDays) {
+                    let stopDaysList = settings.stopDays.split(',').map(Number); // convert string weekdays into integer values
+                    while(!stopDaysList.includes(stop_datetime.getDay())) {
+                        stop_datetime.setDate(stop_datetime.getDate() + 1); // if stop_datetime's weekday is not in the list, add one day
+                    }
+            }
+        }
+
         do {
+            if (stop_datetime !== null && new Date() > stop_datetime) { active = false; break; }
+
             let job = await nextJob(client, settings);
 
             // if the worker has been deactivated, exit this loop


### PR DESCRIPTION
This PR introduces two new arguments to the command line interface for nexrender-worker:

--stop-at-time: This parameter allows users to specify a certain local time when the worker will terminate. An example usage would be --stop-at-time=5:00, which will stop the worker at 5 am local time.

--stop-days: This parameter works in conjunction with the --stop-at-time parameter and allows to specify on which weekdays the worker should terminate. The days are represented as numbers where 0 is Sunday and 6 is Saturday. For instance, --stop-days=1,2,3,4,5 will stop the worker at the specified time from Monday through Friday.

This enhancement increases the flexibility of controlling worker runtime and can help schedule tasks more effectively.

Example use:
```nexrender-worker-win64.exe --host=http://my-host:3000 --multi-frames --stop-at-time=5:00 --stop-days=1,2,3,4,5```
This will stop the worker at 5am from Monday through Friday.

Please review and provide any feedback.
