### PR TITLE
add apostrophe escapement to wrapFootage

### DIFF
--- a/packages/nexrender-core/src/tasks/script/wrap-footage.js
+++ b/packages/nexrender-core/src/tasks/script/wrap-footage.js
@@ -6,7 +6,7 @@ const wb = (value) => (value ? 'true' : 'false')
 
 const wrapFootage = (job, settings, { dest, ...asset }) => (`(function() {
     ${selectLayers(job, asset, `function(layer) {
-        nexrender.replaceFootage(layer, '${checkForWSL(dest.replace(/\\/g, "\\\\"), settings)}', ${wb(asset.sequence)}, ${wb(asset.removeOld)})
+        nexrender.replaceFootage(layer, '${checkForWSL(dest.replace(/\\/g, "\\\\").replace(/'/,"\\'"), settings)}', ${wb(asset.sequence)}, ${wb(asset.removeOld)})
     }`)}
 })();\n`)
 


### PR DESCRIPTION
As described in this issue https://github.com/inlife/nexrender/issues/1008
> If an asset of the project has an apostrophe in the path then the generated nexrender-script is faulty, raising an error "SyntaxError: Expected: )"
> 
> **Information about environment** Version of nexrender-worker-win.exe: 1.50.7 Version of nexrender-server-linux: 1.49.3 Both of them are precompiled versions from the download page
> 
> The workers are running on Windows 11 Pro The server is running on a Debian
> 
> After cloning the repository I could find the issue on [line 9 of the file packages/nexrender-core/src/tasks/script/wrap-footage.js](https://github.com/inlife/nexrender/blob/63c93f142f3f30916dd2817a0e83bfad1d9d94b3/packages/nexrender-core/src/tasks/script/wrap-footage.js#L9) which doesn't escape them.
> 
> Expected behavior: Special characters should be escaped as they can't be preemptively escaped, due to the same line that will escape the backslash ![Commandline error](https://private-user-images.githubusercontent.com/137073763/353544784-3172798f-d701-40c5-a40f-b72ab13b879c.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjI0MTQyNjEsIm5iZiI6MTcyMjQxMzk2MSwicGF0aCI6Ii8xMzcwNzM3NjMvMzUzNTQ0Nzg0LTMxNzI3OThmLWQ3MDEtNDBjNS1hNDBmLWI3MmFiMTNiODc5Yy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzMxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDczMVQwODE5MjFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01MmU2Y2NiNjBlNDA0ZDg2YWE3YjNiOTU2MmUzOTY0ZGZhMmY2MWJiMjQzOWY3YTg4MTliYmYzOGQ4ODkzODgyJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.grf1PaRt4knO6xrnf7h8mn6-JsSqcuWTu_E6Ugck3hI)
> 
> ![Faulty line](https://private-user-images.githubusercontent.com/137073763/353543737-8395c6b4-c7b7-4763-a5e3-bf22a59f8214.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjI0MTQyNjEsIm5iZiI6MTcyMjQxMzk2MSwicGF0aCI6Ii8xMzcwNzM3NjMvMzUzNTQzNzM3LTgzOTVjNmI0LWM3YjctNDc2My1hNWUzLWJmMjJhNTlmODIxNC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzMxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDczMVQwODE5MjFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01YTdlMzhjZWFhOGUwYTI2NDQzNmRlNDYwODY3OWIyMzRiY2I3YzEzZGVhY2YyY2Y4M2ZjOTk1Yjg3ODkzZDRiJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.bXEsV5izx2HOfFTdckqGd32RqDCDETVklSgoUA6LSFo)

Apostrophe not being escaped result in the nexrender script unusable, here is a quick fix for that 