### PR TITLE
Add language support for rendering errors and progress logs

### DIFF
--- a/packages/nexrender-core/src/tasks/render.js
+++ b/packages/nexrender-core/src/tasks/render.js
@@ -3,11 +3,19 @@ const path = require('path')
 const {spawn} = require('child_process')
 const {expandEnvironmentVariables, checkForWSL} = require('../helpers/path')
 
-const progressRegex = /([\d]{1,2}:[\d]{2}:[\d]{2}:[\d]{2})\s+(\(\d+[UL]?\))/gi;
-const durationRegex = /Duration:\s+([\d]{1,2}:[\d]{2}:[\d]{2}:[\d]{2})/gi;
-const startRegex = /Start:\s+([\d]{1,2}:[\d]{2}:[\d]{2}:[\d]{2})/gi;
-const nexrenderErrorRegex = /Error:\s+(nexrender:.*)$/gim;
-const errorRegex = /aerender Error:\s*(.*)$/gis;
+const translations = {
+    "en": {
+        "duration": "Duration",
+        "error"   : "Error",
+        "start"   : "Start"
+    },
+    "de": {
+        "duration": "Dauer",
+        "error"   : "Fehler",
+        "start"   : "Anfang"
+    }
+};
+
 
 const option = (params, name, ...values) => {
     if (values !== undefined) {
@@ -24,6 +32,17 @@ const seconds = (string) => string.split(':')
  */
 module.exports = (job, settings) => {
     settings.logger.log(`[${job.uid}] rendering job...`);
+
+    if(!settings.language) {
+        settings.lang = "en"
+    }
+
+    const progressRegex = /([\d]{1,2}:[\d]{2}:[\d]{2}:[\d]{2})\s+(\(\d+[UL]?\))/gi;
+    const durationRegex = new RegExp(translations[settings.language].duration + ":\\s+([\\d]{1,2}:[\\d]{2}:[\\d]{2}:[\\d]{2})", "gi");
+    const startRegex = new RegExp(translations[settings.language].start + ":\\s+([\\d]{1,2}:[\\d]{2}:[\\d]{2}:[\\d]{2})", "gi");
+    const nexrenderErrorRegex = new RegExp(translations[settings.language].error + ":\\s+(nexrender:.*)$", "gim");
+    const errorRegex = new RegExp("aerender " + translations[settings.language].error + ":\\s*(.*)$", "gis");
+
 
     // create container for our parameters
     let params = [];

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -46,6 +46,7 @@ const args = arg({
     '--header':                 [String],
 
     '--aerender-parameter':     [String],
+    '--language':               String,
 
     // Aliases
     '-v':           '--version',
@@ -177,6 +178,8 @@ if (args['--help']) {
     --aerender-parameter, --ae              forward parameter to aerender (see Adobe site). Parameters with arguments have to be
                                             enclosed in single quotes. For example:
                                             nexrender --aerender-parameter 'close SAVE_CHANGES' --ae 'i 10' job.json
+                                            
+    --language                              language of local after effects installation. currently only en and de are supported                                        
 
 
   {bold ENV VARS}
@@ -237,6 +240,7 @@ opt('polling',              '--polling');
 opt('wslMap',               '--wsl-map');
 opt('aeParams',             '--aerender-parameter');
 opt('tagSelector',          '--tag-selector');
+opt('language',             '--language');
 
 if(args['--cache-path']){
     opt('cache', '--cache-path');
@@ -270,6 +274,9 @@ if (settings['no-license']) {
 } else {
     settings.addLicense = true;
 }
+
+/* debug implies verbose */
+// settings.verbose = settings.debug;
 
 if (settings['no-analytics']) {
     settings.noAnalytics = true;


### PR DESCRIPTION
This pull request introduces a new feature that adds language support for rendering errors and progress logs in After Effects.


The changes allow users to specify the language of their After Effects installation via a new --language flag. This flag directly impacts the parsing of error and progress messages from the renderer. Syntax and text from these logs can fluctuate based on the language, thus this feature enhances the versatility and compatibility of our tool across multiple language installations.

Changes:
----------

- Introduced a new --language flag to specify the language of After Effects installation.
- Added support for interpretation of error and progress logs in both English and German.
- Created a translation map to easily handle translation of keywords and phrases present in logs

Example use:
--------------
```nexrender-worker-win64.exe --host=http://my-host:3000 --multi-frames --ae "v ERRORS_AND_PROGRESS" --language de```

Please review and provide any feedback.