### PR TITLE
Fix asset source path handling in cache action

### DIFF
--- a/packages/nexrender-action-cache/index.js
+++ b/packages/nexrender-action-cache/index.js
@@ -58,7 +58,7 @@ async function saveCache(asset, settings, workpath, cacheDirectory){
     }
 
     const fileName = path.basename(asset.src);
-    const from = path.join(workpath, fileName);
+    const from = asset.dest ? asset.dest: path.join(workpath, fileName);
     const to = path.join(cacheDirectory, fileName);
     settings.logger.log(`> Copying from ${from} to ${to}`);
 
@@ -86,7 +86,7 @@ module.exports = (job, settings, { cacheDirectory, ttl, cacheAssets }, type) => 
     }
 
     cacheDirectory = cacheDirectory.replace('~', require('os').homedir());
-    
+
     if (fs.existsSync(cacheDirectory) && !fs.lstatSync(cacheDirectory).isDirectory()) {
         throw new Error(`Cache path of ${cacheDirectory} exists but is not a directory, stopping`);
     }


### PR DESCRIPTION
packages/nexrender-core/src/tasks/download.js will randomize the download destination.

packages/nexrender-action-cache/index.js is still looking for the filename provided as source and will crash if you try caching the template file.

This patch fixes the issue by using the assets dest property if provided.