### PR TITLE
Add configurable SCAN_CHUNK_SIZE for Redis database queries

### DIFF
--- a/packages/nexrender-database-redis/readme.md
+++ b/packages/nexrender-database-redis/readme.md
@@ -11,8 +11,10 @@ npm i @nexrender/database-redis -g
 ## Configuration
 
 In order to use this, `NEXRENDER_DATABASE_PROVIDER` needs to be set to `redis`.
+Also you can define the number of keys to retrieve in a single iteration during the `SCAN` operation using  `SCAN_CHUNK_SIZE`. Default is `10`.
 
 ```
 export NEXRENDER_DATABASE_PROVIDER="redis"
 export REDIS_URL="redis://localhost:6379"
+export SCAN_CHUNK_SIZE="100"
 ```

--- a/packages/nexrender-database-redis/src/index.js
+++ b/packages/nexrender-database-redis/src/index.js
@@ -5,6 +5,8 @@ const client = redis.createClient({
     url: process.env.REDIS_URL
 });
 
+const scanChunkSize = process.env.SCAN_CHUNK_SIZE? process.env.SCAN_CHUNK_SIZE : '10';
+
 client.getAsync = promisify(client.get).bind(client);
 client.setAsync = promisify(client.set).bind(client);
 client.delAsync = promisify(client.del).bind(client);
@@ -16,7 +18,7 @@ const scan = async parser => {
     let results = [];
 
     const _scan = async () => {
-        const [ next, keys ] = await client.scanAsync(cursor, 'MATCH', 'nexjob:*', 'COUNT', '10');
+        const [ next, keys ] = await client.scanAsync(cursor, 'MATCH', 'nexjob:*', 'COUNT', scanChunkSize);
 
         cursor = next;
         results = results.concat(keys);


### PR DESCRIPTION
Introduced the `SCAN_CHUNK_SIZE` environment variable to customize the number of keys retrieved per `SCAN` operation, with a default value of 10. Updated the logic in `index.js` to utilize this variable and documented the change in the README. This enhancement allows for greater flexibility and performance tuning based on specific use cases.