### PR TITLE
Add additional macOS 2025 AE binary path for autofind

### DIFF
--- a/packages/nexrender-core/src/helpers/autofind.js
+++ b/packages/nexrender-core/src/helpers/autofind.js
@@ -15,6 +15,7 @@ const defaultPaths = {
         '/Applications/Adobe After Effects 2022',
         '/Applications/Adobe After Effects 2023',
         '/Applications/Adobe After Effects 2024',
+        '/Applications/Adobe After Effects 2025',
         '/Applications/Adobe After Effects CC 2021',
         '/Applications/Adobe After Effects CC 2022',
         '/Applications/Adobe After Effects CC 2023',


### PR DESCRIPTION
MacOS/Darwin AE installations can be under either of these paths
- `/Applications/Adobe After Effects 20XX/`
- `/Applications/Adobe After Effects CC 20XX/`

This covers both options