### PR TITLE
small fix to provide otf font support in the automatic font installer

### DIFF
--- a/packages/nexrender-action-fonts/index.js
+++ b/packages/nexrender-action-fonts/index.js
@@ -139,7 +139,7 @@ module.exports = async (job, settings, params, type) => {
                 continue;
             }
 
-            if (!asset.src.match(/\.(ttf)$/)) {
+            if (!asset.src.match(/\.(ttf)$/) && !asset.src.match(/\.otf$/)) {
                 continue;
             }
 

--- a/packages/nexrender-action-fonts/index.js
+++ b/packages/nexrender-action-fonts/index.js
@@ -165,7 +165,7 @@ module.exports = async (job, settings, params, type) => {
                 continue;
             }
 
-            if (!asset.src.match(/\.(ttf)$/)) {
+            if (!asset.src.match(/\.(ttf)$/) && !asset.src.match(/\.otf$/)) {
                 continue;
             }
 

--- a/packages/nexrender-action-fonts/index.js
+++ b/packages/nexrender-action-fonts/index.js
@@ -144,7 +144,7 @@ module.exports = async (job, settings, params, type) => {
             }
 
             if (!asset.name) {
-                throw new Error(`Asset ${asset.src} has to be named using the "name" property that would contain the font name as it is used to be then used in the After Effets project.`);
+                throw new Error(`Asset ${asset.src} has to be named using the "name" property that would contain the font name as it is used to be then used in the After Effects project.`);
             }
 
             if (process.platform === "darwin") {


### PR DESCRIPTION
this small code change should prevent .otf font files from being discarded/ignored when auto installing fonts by the fonts-action