### PR TITLE
Resolve issue #1062

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -33,7 +33,8 @@ const download = (job, settings, asset) => {
     if (protocol === 'data' && !asset.layerName) {
         destName = Math.random().toString(36).substring(2);
     } else {
-        destName = path.basename(asset.src)
+        // Use uri.pathname to avoid issues with forward slashes in query parameters (e.g., Adobe Scene7 URLs)
+        destName = path.basename(uri.pathname || asset.src)
         destName = destName.indexOf('?') !== -1 ? destName.slice(0, destName.indexOf('?')) : destName;
         /* ^ remove possible query search string params ^ */
         destName = decodeURI(destName) /* < remove/decode any special URI symbols within filename */

--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -34,7 +34,7 @@ const download = (job, settings, asset) => {
         destName = Math.random().toString(36).substring(2);
     } else {
         // Use uri.pathname to avoid issues with forward slashes in query parameters (e.g., Adobe Scene7 URLs)
-        destName = path.basename(uri.pathname || asset.src)
+        destName = uri.pathname || path.basename(asset.src)
         destName = destName.indexOf('?') !== -1 ? destName.slice(0, destName.indexOf('?')) : destName;
         /* ^ remove possible query search string params ^ */
         destName = decodeURI(destName) /* < remove/decode any special URI symbols within filename */


### PR DESCRIPTION
The incorrect basename was extracted, which potentially can create an invalid Windows path, failing the render.